### PR TITLE
clean up logging, duplicate error messages

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "test_*.py"
+  - "src/supervisor/example.py"

--- a/src/supervisor/__init__.py
+++ b/src/supervisor/__init__.py
@@ -1,0 +1,5 @@
+"""__init__.py: set NullHandler for any package logs"""
+
+import logging
+
+logger = logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/supervisor/example.py
+++ b/src/supervisor/example.py
@@ -6,6 +6,7 @@ An example implementation using Supervisor to catch an error and email both the 
 
 import logging
 import logging.handlers
+import socket
 from pathlib import Path
 
 from supervisor.message_handlers import EmailHandler
@@ -26,7 +27,7 @@ if __name__ == '__main__':
     test_logger.info('test run')
 
     #: Instantiate a Supervisor object
-    sim_sup = Supervisor('supervisor', test_path)
+    sim_sup = Supervisor('supervisor', log=test_logger, log_path=test_path)
 
     #: Specify the email server and addresses
     email_settings = {
@@ -34,6 +35,7 @@ if __name__ == '__main__':
         'smtpPort': 25,
         'from_address': 'noreply@utah.gov',
         'to_addresses': 'jdadams@utah.gov',
+        'prefix': f'Example on {socket.gethostname()}: '
     }
 
     #: Instantiate a new EmailHandler and register it with our Supervisor

--- a/src/supervisor/example.py
+++ b/src/supervisor/example.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
     test_logger.info('test run')
 
     #: Instantiate a Supervisor object
-    sim_sup = Supervisor('supervisor', log=test_logger, log_path=test_path)
+    sim_sup = Supervisor('supervisor', logger=test_logger, log_path=test_path)
 
     #: Specify the email server and addresses
     email_settings = {

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -74,12 +74,12 @@ class EmailHandler(MessageHandler):  # pylint: disable=too-few-public-methods
             smtp_port = self.email_settings['smtpPort']
 
         except KeyError:
-            warnings.warn('Required environment variables for sending emails do not exist. No emails sent.')
+            warnings.warn('Required email settings do not exist. No emails sent.')
             return
 
         for setting in [from_address, to_addresses, smtp_server, smtp_port]:
             if not setting:
-                warnings.warn('Required environment variables for sending emails exist but not set. No emails sent.')
+                warnings.warn('Required email settings exist but aren\'t populated. No emails sent.')
                 return
 
         message = self._build_message(message_details)

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -128,7 +128,10 @@ class EmailHandler(MessageHandler):  # pylint: disable=too-few-public-methods
             to_addresses_joined = to_addresses
 
         #: Add various elements of the message
-        message['Subject'] = subject
+        if 'prefix' in self.email_settings:
+            message['Subject'] = self.email_settings['prefix'] + subject
+        else:
+            message['Subject'] = subject
         message['From'] = self.email_settings['from_address']
         message['To'] = to_addresses_joined
 

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -77,6 +77,11 @@ class EmailHandler(MessageHandler):  # pylint: disable=too-few-public-methods
             warnings.warn('Required environment variables for sending emails do not exist. No emails sent.')
             return
 
+        for setting in [from_address, to_addresses, smtp_server, smtp_port]:
+            if not setting:
+                warnings.warn('Required environment variables for sending emails exist but not set. No emails sent.')
+                return
+
         message = self._build_message(message_details)
 
         #: Send message

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -111,7 +111,7 @@ class EmailHandler(MessageHandler):  # pylint: disable=too-few-public-methods
         message = MIMEMultipart()
         message.attach(MIMEText(message_details.message, 'html'))
 
-        #: TODO: Not sure how often this is coming comming thorugh, may need more work.
+        #: Get the client's version (assuming client has been installed via pip install and setup.py)
         distributions = pkg_resources.require(project_name)
         if distributions:
             version = distributions[0].version

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -4,7 +4,7 @@ message_handlers.py: Holds all the different message handlers
 
 import gzip
 import io
-import logging
+import warnings
 from abc import ABC, abstractmethod
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
@@ -66,17 +66,15 @@ class EmailHandler(MessageHandler):  # pylint: disable=too-few-public-methods
             have .log_file and .attachments
         """
 
-        log = logging.getLogger(message_details.project_name)
-
         #: Configure outgoing settings
-        from_address = self.email_settings['from_address']
-        to_addresses = self.email_settings['to_addresses']
-        smtp_server = self.email_settings['smtpServer']
-        smtp_port = self.email_settings['smtpPort']
+        try:
+            from_address = self.email_settings['from_address']
+            to_addresses = self.email_settings['to_addresses']
+            smtp_server = self.email_settings['smtpServer']
+            smtp_port = self.email_settings['smtpPort']
 
-        if None in [from_address, to_addresses, smtp_server, smtp_port]:
-            log.warning('Required environment variables for sending emails do not exist. No emails sent.')
-
+        except KeyError:
+            warnings.warn('Required environment variables for sending emails do not exist. No emails sent.')
             return
 
         message = self._build_message(message_details)

--- a/src/supervisor/models.py
+++ b/src/supervisor/models.py
@@ -93,7 +93,7 @@ class Supervisor:
             message_details = MessageDetails()
             message_details.message = error
             message_details.subject = 'ERROR'
-            message_details.log_file = self.log_path
+            message_details.attachments = [self.log_path]
             message_details.project_name = self.project_name
             self.notify(message_details)
 
@@ -108,9 +108,7 @@ class MessageDetails:  # pylint: disable=too-few-public-methods
     message : str
         The text of the message
     attachment : list
-        Strings or Paths to any attachments
-    log_file : Path
-        Path to an on-disk log file
+        Strings or Paths to any attachments, including log files
     subject : str
         The message subject
     project_name : str
@@ -122,6 +120,5 @@ class MessageDetails:  # pylint: disable=too-few-public-methods
     def __init__(self):
         self.message = ''
         self.attachments = []  #: Strings or Paths
-        self.log_file = None  #: Path
         self.subject = ''
         self.project_name = ''

--- a/src/supervisor/models.py
+++ b/src/supervisor/models.py
@@ -4,6 +4,7 @@ This module holds the classes used by supervisor
 
 import logging
 import os
+import socket
 import sys
 import traceback
 
@@ -34,10 +35,9 @@ class Supervisor:
 
     def __init__(self, project_name, log_path=None):
 
-        #: Set up our list of MessageHandlers and add a default ConsoleHandler
+        #: Set up our list of MessageHandlers
         self.project_name = project_name
         self.message_handlers = []
-        self.message_handlers.append(ConsoleHandler())
         self.log_path = log_path
 
         #: Catch any uncaught exception with our custom exception handler
@@ -92,7 +92,7 @@ class Supervisor:
 
             message_details = MessageDetails()
             message_details.message = error
-            message_details.subject = f'{self.project_name}: ERROR'
+            message_details.subject = f'{self.project_name} on {socket.gethostname()}: ERROR'
             message_details.log_file = self.log_path
             self.notify(message_details)
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -122,7 +122,7 @@ def test_gzip_not_called_for_non_existant_attachments(mocker, tmp_path):
     assert not handler_mock._build_gzip_attachment.called
 
 
-def test_gzip_called_4_times_for_3_attachments_and_log(mocker, tmp_path):
+def test_gzip_called_3_times_for_3_attachments(mocker, tmp_path):
 
     distribution_Mock = mocker.Mock()
     distribution_Mock.version = 0
@@ -136,16 +136,11 @@ def test_gzip_called_4_times_for_3_attachments_and_log(mocker, tmp_path):
             attfile.write(f'att{i}')
         atts.append(path)
 
-    log_path = tmp_path / 'log'
-    with open(log_path, 'w') as logfile:
-        logfile.write('log')
-
     message_details = MessageDetails()
     message_details.message = 'test_message'
     message_details.subject = 'test_subject'
     message_details.project_name = 'testing'
     message_details.attachments.extend(atts)
-    message_details.log_file = log_path
 
     handler_mock = mocker.Mock()
     handler_mock.email_settings = {
@@ -155,7 +150,7 @@ def test_gzip_called_4_times_for_3_attachments_and_log(mocker, tmp_path):
 
     test_message = message_handlers.EmailHandler._build_message(handler_mock, message_details)
 
-    assert handler_mock._build_gzip_attachment.call_count == 4
+    assert handler_mock._build_gzip_attachment.call_count == 3
 
 
 def test_gzipper(mocker, tmp_path):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -41,6 +41,34 @@ def test_build_message_without_attachments(mocker):
     assert test_message.get_payload()[1].get_payload() == '<p>testing version: 0</p>'
 
 
+def test_build_message_with_subject_prefix(mocker):
+
+    distribution_Mock = mocker.Mock()
+    distribution_Mock.version = 0
+    distributions = [distribution_Mock]
+    mocker.patch('pkg_resources.require', return_value=distributions)
+
+    message_details = MessageDetails()
+    message_details.message = 'test_message'
+    message_details.subject = 'test_subject'
+    message_details.project_name = 'testing'
+
+    handler_mock = mocker.Mock()
+    handler_mock.email_settings = {
+        'to_addresses': 'foo@example.com',
+        'from_address': 'testing@example.com',
+        'prefix': 'test prefix: ',
+    }
+
+    test_message = message_handlers.EmailHandler._build_message(handler_mock, message_details)
+
+    assert test_message.get('Subject') == 'test prefix: test_subject'
+    assert test_message.get('To') == 'foo@example.com'
+    assert test_message.get('From') == 'testing@example.com'
+    assert test_message.get_payload()[0].get_payload() == 'test_message'
+    assert test_message.get_payload()[1].get_payload() == '<p>testing version: 0</p>'
+
+
 def test_build_message_with_multiple_to_addresses(mocker):
 
     distribution_Mock = mocker.Mock()

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,3 +1,5 @@
+import pytest
+
 from supervisor import message_handlers
 from supervisor.models import MessageDetails
 
@@ -168,3 +170,150 @@ def test_gzipper(mocker, tmp_path):
     assert attachment.get_content_type() == 'application/x-gzip'
     assert attachment.get_content_disposition() == 'attachment'
     assert attachment.get_payload()
+
+    # email_settings = {
+    #     'smtpServer': 'foo.example',
+    #     'smtpPort': 25,
+    #     'from_address': 'foo@bar',
+    #     'to_addresses': 'baz@bar',
+    # }
+
+
+def test_send_message_catches_missing_server(mocker):
+
+    builder_mock = mocker.patch('supervisor.message_handlers.EmailHandler._build_message')
+    email_settings = {
+        'smtpPort': 25,
+        'from_address': 'foo@bar',
+        'to_addresses': 'baz@bar',
+    }
+    details = mocker.Mock()
+
+    with pytest.warns(UserWarning):
+        email_handler = message_handlers.EmailHandler(email_settings)
+        email_handler.send_message(details)
+
+    builder_mock.assert_not_called()
+
+
+def test_send_message_catches_missing_port(mocker):
+
+    builder_mock = mocker.patch('supervisor.message_handlers.EmailHandler._build_message')
+    email_settings = {
+        'smtpServer': 'foo.example',
+        'from_address': 'foo@bar',
+        'to_addresses': 'baz@bar',
+    }
+    details = mocker.Mock()
+
+    with pytest.warns(UserWarning):
+        email_handler = message_handlers.EmailHandler(email_settings)
+        email_handler.send_message(details)
+
+    builder_mock.assert_not_called()
+
+
+def test_send_message_catches_missing_from_address(mocker):
+
+    builder_mock = mocker.patch('supervisor.message_handlers.EmailHandler._build_message')
+    email_settings = {
+        'smtpServer': 'foo.example',
+        'smtpPort': 25,
+        'to_addresses': 'baz@bar',
+    }
+    details = mocker.Mock()
+
+    with pytest.warns(UserWarning):
+        email_handler = message_handlers.EmailHandler(email_settings)
+        email_handler.send_message(details)
+
+    builder_mock.assert_not_called()
+
+
+def test_send_message_catches_missing_to_address(mocker):
+
+    builder_mock = mocker.patch('supervisor.message_handlers.EmailHandler._build_message')
+    email_settings = {
+        'smtpServer': 'foo.example',
+        'smtpPort': 25,
+        'from_address': 'foo@bar',
+    }
+    details = mocker.Mock()
+
+    with pytest.warns(UserWarning):
+        email_handler = message_handlers.EmailHandler(email_settings)
+        email_handler.send_message(details)
+
+    builder_mock.assert_not_called()
+
+
+def test_send_message_catches_blank_server(mocker):
+
+    builder_mock = mocker.patch('supervisor.message_handlers.EmailHandler._build_message')
+    email_settings = {
+        'smtpServer': '',
+        'smtpPort': 25,
+        'from_address': 'foo@bar',
+        'to_addresses': 'baz@bar',
+    }
+    details = mocker.Mock()
+
+    with pytest.warns(UserWarning):
+        email_handler = message_handlers.EmailHandler(email_settings)
+        email_handler.send_message(details)
+
+    builder_mock.assert_not_called()
+
+
+def test_send_message_catches_blank_port(mocker):
+
+    builder_mock = mocker.patch('supervisor.message_handlers.EmailHandler._build_message')
+    email_settings = {
+        'smtpServer': 'foo.example',
+        'smtpPort': None,
+        'from_address': 'foo@bar',
+        'to_addresses': 'baz@bar',
+    }
+    details = mocker.Mock()
+
+    with pytest.warns(UserWarning):
+        email_handler = message_handlers.EmailHandler(email_settings)
+        email_handler.send_message(details)
+
+    builder_mock.assert_not_called()
+
+
+def test_send_message_catches_blank_from_address(mocker):
+
+    builder_mock = mocker.patch('supervisor.message_handlers.EmailHandler._build_message')
+    email_settings = {
+        'smtpServer': 'foo.example',
+        'smtpPort': 25,
+        'from_address': '',
+        'to_addresses': 'baz@bar',
+    }
+    details = mocker.Mock()
+
+    with pytest.warns(UserWarning):
+        email_handler = message_handlers.EmailHandler(email_settings)
+        email_handler.send_message(details)
+
+    builder_mock.assert_not_called()
+
+
+def test_send_message_catches_blank_to_address(mocker):
+
+    builder_mock = mocker.patch('supervisor.message_handlers.EmailHandler._build_message')
+    email_settings = {
+        'smtpServer': 'foo.example',
+        'smtpPort': 25,
+        'from_address': 'foo@bar',
+        'to_addresses': '',
+    }
+    details = mocker.Mock()
+
+    with pytest.warns(UserWarning):
+        email_handler = message_handlers.EmailHandler(email_settings)
+        email_handler.send_message(details)
+
+    builder_mock.assert_not_called()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,8 +9,6 @@ def test_supervisor_constructor_does_proper_setup(mocker):
 
     sim_sup = models.Supervisor('test project')
 
-    assert len(sim_sup.message_handlers) == 1
-    assert type(sim_sup.message_handlers[0]) == message_handlers.ConsoleHandler
     assert exceptions_mock.called_once()
 
 
@@ -53,5 +51,5 @@ def test_add_message_handler(mocker):
 
     sim_sup.add_message_handler(handler_mock)
 
-    assert len(sim_sup.message_handlers) == 2
+    assert len(sim_sup.message_handlers) == 1
     assert sim_sup.message_handlers[-1] == handler_mock


### PR DESCRIPTION
Lots of study on `logging` to properly understand supervisor's role in a client's logging setup. Client is now responsible for passing a log to supervisor if it wants to log any uncaught exceptions.

Other minor cleanup: remove unnecessary console handler, generalize log file attachments, report version in global exception handler by sending project name... I'm probably missing something.