### PR TITLE
feat: add SendGrid handler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.7
 
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ cov.xml
 .coverage
 
 src/supervisor/secrets.py
+.vscode/.ropeproject/config.py

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ __pycache__
 .DS_Store
 cov.xml
 .coverage
+
+src/supervisor/secrets.py

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ supervisor provides a framework for scripts scheduled through Windows' Task Sche
 - Redirects exception handling to a custom handler
 - Provides custom messaging handler to direct errors and any other end-of-script output to e-mail and (eventually) Slack
   - Works with any SMTP server supported by Python's `smtp` library
+  - Works with the SendGrid email API
 - Binds messaging settings and credentials to project (maybe not the best thing? Still have to change them project-by-project, but they will be in a consistent location in each project)
 
 ## Usage
@@ -23,12 +24,15 @@ See `api.md` for an in-depth description of Supervisor and how it's used.
    - `cd c:\root\path\where\you\store\your\code` (ie, `cd c:\gis\git`)
 1. Install supervisor (or add to your project's `setup.py`)
    - `pip install agrc-supervisor`
-1. In your script's entry point code (usually `main.py`), before any arg parsing:
-   - Instantiate a `Supervisor` object, passing in the name of your project
+1. In your script's entry point code (usually `main.py`), as early as possible and generally before any arg parsing:
+   - Instantiate a `Supervisor` object
+   - Instantiate and register the desired `MessageHandler`s with the `Supervisor Object`
+      - Create the appropriate settings dictionaries before creating the `MessageHandler`s
 1. Call `.notify()` on the `Supervisor` object after your business logic:
-   - In `main.py` (or wherever you instantiated the object), passing the message and path to the log file
+   - In `main.py` (or wherever you instantiated the `Supervisor` object), passing the message and path to the log file
    - —OR—
    - Elsewhere in your business logic, having passed your `Supervisor` object through your logic as needed.
+1. After instantiation, the `Supervisor` object will direct all errors to its custom error handler. This will send messages to every registered handler whenever an error occurs.
 
 ## Development Environment
 

--- a/api.md
+++ b/api.md
@@ -8,10 +8,9 @@ The Supervisor is the main object used to coordinate messaging and error handlin
 
 ### Attributes
 
-- `project_name` (str): The name of the client project using Supervisor; used to report version in global exception handler messages
 - `message_handlers` (List): Notifications will be sent via all handlers in this list
-- `logger` (Logger): Logger object to use in global exception handler
-- `log_path` (Path): Path to a logfile to send in exception messages
+- `logger` (Logger, optional): Logger object to use in global exception handler
+- `log_path` (Path, optional): Path to a logfile to attach to exception messages
 
 ### Methods
 
@@ -24,13 +23,13 @@ The Supervisor is the main object used to coordinate messaging and error handlin
 
 You'll instantiate a single Supervisor object to handle messaging and exceptions for the client program (whatever program you're wanting to automate through Windows Task Scheduler).
 
-The three arguments on the constructor are used to create messages in the exception handler. `name` is added to the subject of exception messages and should match the client's python module name. The `logger` will be used to log any errors caught by the exception handler. `log_path` will be added as an attachment to any exception messages.
+The optional logging arguments on the constructor can be used messages in the exception handler. The `logger` will be used to log any errors caught by the exception handler. `log_path` will be added as an attachment to any exception messages.
 
 The information in these parameters are not passed to any message handler by default. Any information must be passed as part of a MessageDetails object.
 
 #### Sending Notifications
 
-After you've instantiated a Supervisor object, add whichever MessageHandler objects you want to use to send notifications. Currently, only the EmailHandler and ConsoleHandler handlers have been implemented.
+After you've instantiated a Supervisor object, add whichever MessageHandler objects you want to use to send notifications. Currently, the EmailHandler, SendGridHandler, and ConsoleHandler handlers have been implemented.
 
 To send a notification, call the `.notify()` method on your Supervisor with a MessageDetails parameter. It will send the details to each registered handler, which handle the formatting and sending depending on each specific implementation.
 
@@ -38,24 +37,25 @@ To send a notification, call the `.notify()` method on your Supervisor with a Me
 
 `models.MessageDetails`
 
-MessageDetails is a simple data structure for holding information about your message. Using an object provides dot-access to the message elements and IDE hinting/autocomplete.
+MessageDetails is a simple data structure for holding information about your message. Using an object provides dot-access to the message elements, property setters, and IDE hinting/autocomplete.
 
 ### Attributes
 
 - `message` (str): The text of the message
 - `attachment` (List): Strings or Paths to any attachments, including log files
 - `subject` (str): The message subject
-- `project_name` (str): The name of the project that has added the Supervisor object. Used for adding the version to notifications.
 
 ### Usage
 
 Instantiate a new MessageDetails object for each notification you want to send. Different handlers will require different elements; verify with the message handler(s) you're using.
 
+The `.attachment` property has a setter that will add anything you assign to this value to the attachment list. You can assign either a str or a list of strs and it will handle the list appending/extending internally. You can make additional assignments to `.attachment` in your program to add additional attachments. There is currently no capability to remove items from the list or empty the list.
+
 Pass the MessageDetails object to the handlers as the parameter of the `Supervisor.notify()` method.
 
 # Handlers
 
-All message handlers are implementations of the MessageHandler abstract base class. They must implement the `send_message()` method which accepts a MessageDetails object, formats it specific to the destination, and sends the message. Hidden helper methods can be used to simplify `send_message()` if necessary.
+All message handlers are implementations of the MessageHandler abstract base class. They must implement the `send_message()` method which accepts a MessageDetails object, formats it specific to the destination, and sends the message. Private helper methods are used to simplify `send_message()`.
 
 ## EmailHandler
 
@@ -67,25 +67,54 @@ A handler to send MIME emails via smptlib. Supports multiple recipients, HTML-fo
 
 Relies on the `email_settings` parameter to set up the outgoing server settings. This dictionary requires four items:
 
-- `smtpServer`: the outgoing server DNS name or ip address
-- `smtpPort`: the outgoing port (usually 25)
-- `from_address`: account to send emails from
+- `smtpServer`: The outgoing server DNS name or ip address
+- `smtpPort`: The outgoing port (usually 25)
+- `from_address`: Account to send emails from
 - `to_addresses`: A string or list of strings specifying the recipient addresses
 
-Optionally supports the `prefix` value, which is a string that will be prepended to the message's subject line. You can use `socket.gethostname()` to include the current hostname.
+Optionally supports the `prefix` key in `email_settings`, which is a string that will be prepended to the message's subject line. You can use `socket.gethostname()` to include the current hostname.
+
+Optionally relies on the `project_name` parameter to report the client program's name and version number in the email.
 
 ### Supported MessageDetail Attributes
 
 #### Required
 
 - `message`: The message to send formatted as a single string.
-- `subject`: Message subject (will have the email_setting's prefix prepended if present)
-- `project_name`: Name of the client program using Supervisor
-  - Used to get the current version of the client.
+- `subject`: Message subject (will have the `email_setting` prefix prepended if present)
 
 #### Optional
 
 - `attachments`: Path(s) to attachments to include with the email. Will be gzipped prior to attaching.
+
+## SendGridHandler
+
+`message_handlers.SendGridHandler`
+
+A handler to send plaintext emails via the SendGrid service. Supports multiple recipients, plaintext-formatted messages, and attachments (which will be zipped). As plaintext, it preserves traceback formatting in the message.
+
+### Instantiation
+
+Relies on the `sendgrid_settings` parameter to set up the outgoing server settings. This dictionary requires four items:
+
+- `api_key`: API key for the SendGrid service
+- `from_address`: Account to send emails from
+- `to_addresses`: A string or list of strings specifying the recipient addresses
+
+Optionally supports the `prefix` key in `sendgrid_settings`, which is a string that will be prepended to the message's subject line. You can use `socket.gethostname()` to include the current hostname.
+
+Optionally relies on the `project_name` parameter to report the client program's name and version number in the email.
+
+### Supported MessageDetail Attributes
+
+#### Required
+
+- `message`: The message to send formatted as a single string.
+- `subject`: Message subject (will have the `sendgrid_setting` prefix prepended if present)
+
+#### Optional
+
+- `attachments`: Path(s) to attachments to include with the email. Will be zipped prior to attaching.
 
 ## SlackHandler
 

--- a/api.md
+++ b/api.md
@@ -10,7 +10,7 @@ The Supervisor is the main object used to coordinate messaging and error handlin
 
 - `message_handlers` (List): Notifications will be sent via all handlers in this list
 - `logger` (Logger, optional): Logger object to use in global exception handler
-- `log_path` (Path, optional): Path to a logfile to attach to exception messages
+- `log_path` (Path, optional): Path to a logfile to attach to exception messages sent via `.notify()` (usually emails)
 
 ### Methods
 
@@ -23,7 +23,7 @@ The Supervisor is the main object used to coordinate messaging and error handlin
 
 You'll instantiate a single Supervisor object to handle messaging and exceptions for the client program (whatever program you're wanting to automate through Windows Task Scheduler).
 
-The optional logging arguments on the constructor can be used messages in the exception handler. The `logger` will be used to log any errors caught by the exception handler. `log_path` will be added as an attachment to any exception messages.
+The optional logging arguments on the constructor can be used by the exception handler. The `logger` will be used to log any errors caught by the exception handler. `log_path` can be added as an attachment to any exception messages sent by the registered `MessageHandlers`.
 
 The information in these parameters are not passed to any message handler by default. Any information must be passed as part of a MessageDetails object.
 

--- a/pylintrc
+++ b/pylintrc
@@ -3,4 +3,5 @@ load-plugins=pylint_quotes
 max-line-length=120
 disable=bad-continuation,broad-except
 ignore-patterns=test_.*?py
+ignore=secrets.py,example.py
 generated-members=arcpy.da.SearchCursor,arcpy.da.UpdateCursor,arcpy.da.Describe,arcpy.env.scratchFolder,arcpy.env.scratchGDB

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,4 +16,4 @@ norecursedirs = .env data maps
 show_capture = True
 minversion = 3.5
 console_output_style = count
-addopts = --pylint --cov-branch --cov=supervisor --cov-report term --cov-report xml:cov.xml --instafail --isort
+addopts = --pylint --cov-branch --cov=supervisor --cov-report term --cov-report xml:cov.xml --instafail

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     keywords=['gis'],
     install_requires=[
         'requests',
-        'sendgrid',
+        'sendgrid==6.7.*',
     ],
     extras_require={
         'tests': [

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     },
     keywords=['gis'],
     install_requires=[
-        'requests',
+        'requests==2.25.*',
         'sendgrid==6.7.*',
     ],
     extras_require={
@@ -43,7 +43,7 @@ setup(
             'pytest-cov==2.9.*',
             'pytest-instafail==0.4.*',
             'pytest-isort==1.0.*',
-            'pytest-mock',
+            'pytest-mock==3.4.*',
             'pytest-pylint==0.17.*',
             'pytest-watch==4.2.*',
             'pytest==5.4.*',

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     keywords=['gis'],
     install_requires=[
         'requests',
+        'sendgrid',
     ],
     extras_require={
         'tests': [

--- a/src/supervisor/example.py
+++ b/src/supervisor/example.py
@@ -29,23 +29,23 @@ if __name__ == '__main__':
     test_logger.info(f'test run: {datetime.datetime.now()}')
 
     #: Instantiate a Supervisor object
-    sim_sup = Supervisor('supervisor', logger=test_logger, log_path=test_path)
+    sim_sup = Supervisor(logger=test_logger, log_path=test_path)
 
     #: ============
     #: EmailHandler
     #: ============
 
-    # #: Specify the email server and addresses
-    # email_settings = {
-    #     'smtpServer': 'send.state.ut.us',
-    #     'smtpPort': 25,
-    #     'from_address': 'noreply@utah.gov',
-    #     'to_addresses': 'jdadams@utah.gov',
-    #     'prefix': f'Example on {socket.gethostname()}: '
-    # }
+    #: Specify the email server and addresses
+    email_settings = {
+        'smtpServer': 'send.state.ut.us',
+        'smtpPort': 25,
+        'from_address': 'noreply@utah.gov',
+        'to_addresses': 'jdadams@utah.gov',
+        'prefix': f'Example on {socket.gethostname()}: '
+    }
 
-    # #: Instantiate a new EmailHandler and register it with our Supervisor
-    # sim_sup.add_message_handler(EmailHandler(email_settings))
+    #: Instantiate a new EmailHandler and register it with our Supervisor
+    sim_sup.add_message_handler(EmailHandler(email_settings, 'agrc-supervisor'))
 
     #: ===============
     #: SendGridHandler

--- a/src/supervisor/example.py
+++ b/src/supervisor/example.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
     }
 
     #: Instantiate a new SendGridHandler and register it with our Supervisor
-    sim_sup.add_message_handler(SendGridHandler(sendgrid_settings))
+    sim_sup.add_message_handler(SendGridHandler(sendgrid_settings, 'agrc-supervisor'))
 
     #: Send a message with both a directory attachment and a single file attachment
     message = MessageDetails()

--- a/src/supervisor/example.py
+++ b/src/supervisor/example.py
@@ -9,7 +9,8 @@ import logging.handlers
 import socket
 from pathlib import Path
 
-from supervisor.message_handlers import EmailHandler
+from supervisor import secrets
+from supervisor.message_handlers import EmailHandler, SendGridHandler
 from supervisor.models import Supervisor
 
 if __name__ == '__main__':
@@ -29,17 +30,36 @@ if __name__ == '__main__':
     #: Instantiate a Supervisor object
     sim_sup = Supervisor('supervisor', logger=test_logger, log_path=test_path)
 
-    #: Specify the email server and addresses
-    email_settings = {
-        'smtpServer': 'send.state.ut.us',
-        'smtpPort': 25,
+    #: ============
+    #: EmailHandler
+    #: ============
+
+    # #: Specify the email server and addresses
+    # email_settings = {
+    #     'smtpServer': 'send.state.ut.us',
+    #     'smtpPort': 25,
+    #     'from_address': 'noreply@utah.gov',
+    #     'to_addresses': 'jdadams@utah.gov',
+    #     'prefix': f'Example on {socket.gethostname()}: '
+    # }
+
+    # #: Instantiate a new EmailHandler and register it with our Supervisor
+    # sim_sup.add_message_handler(EmailHandler(email_settings))
+
+    #: ===============
+    #: SendGridHandler
+    #: ===============
+
+    #: Specify the to/from addresses, subject prefix, and sendgrid API key
+    sendgrid_settings = {
         'from_address': 'noreply@utah.gov',
         'to_addresses': 'jdadams@utah.gov',
-        'prefix': f'Example on {socket.gethostname()}: '
+        'prefix': f'Example on {socket.gethostname()}: ',
+        'api_key': secrets.SENDGRID_API_KEY,
     }
 
-    #: Instantiate a new EmailHandler and register it with our Supervisor
-    sim_sup.add_message_handler(EmailHandler(email_settings))
+    #: Instantiate a new SendGridHandler and register it with our Supervisor
+    sim_sup.add_message_handler(SendGridHandler(sendgrid_settings))
 
     #: Trigger Supervisor's error handler
     raise ValueError('random error here')

--- a/src/supervisor/example.py
+++ b/src/supervisor/example.py
@@ -4,6 +4,7 @@
 An example implementation using Supervisor to catch an error and email both the traceback and the logfile
 """
 
+import datetime
 import logging
 import logging.handlers
 import socket
@@ -11,7 +12,7 @@ from pathlib import Path
 
 from supervisor import secrets
 from supervisor.message_handlers import EmailHandler, SendGridHandler
-from supervisor.models import Supervisor
+from supervisor.models import MessageDetails, Supervisor
 
 if __name__ == '__main__':
 
@@ -25,7 +26,7 @@ if __name__ == '__main__':
     test_logger.setLevel(logging.DEBUG)
 
     #: Add somethign to the log
-    test_logger.info('test run')
+    test_logger.info(f'test run: {datetime.datetime.now()}')
 
     #: Instantiate a Supervisor object
     sim_sup = Supervisor('supervisor', logger=test_logger, log_path=test_path)
@@ -60,6 +61,13 @@ if __name__ == '__main__':
 
     #: Instantiate a new SendGridHandler and register it with our Supervisor
     sim_sup.add_message_handler(SendGridHandler(sendgrid_settings))
+
+    #: Send a message with both a directory attachment and a single file attachment
+    message = MessageDetails()
+    message.subject = '[Supervisor Example]'
+    message.message = 'This is an example message\nwith a newline\nor two.'
+    message.attachments = [r'c:\temp\agol_items_by_user', r'c:\temp\schools.csv']
+    sim_sup.notify(message)
 
     #: Trigger Supervisor's error handler
     raise ValueError('random error here')

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -294,6 +294,15 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
         return Content('text/plain', message)
 
     def _verify_attachments(self, attachments):
+        """Make sure attachments are legitimate Paths
+
+        Args:
+            attachments (List): strs or Paths of files to be attached
+
+        Returns:
+            str, List: Warning message to be appended to main message, list of verified attachments
+        """
+
         error_message = ''
         good_attachments = []
         for attachment in attachments:

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -206,7 +206,7 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
         recipient_addresses = self._build_recipient_addresses(to_addresses)
 
         subject = self._build_subject(message_details)
-        content = self._build_content(message_details)
+        content = self._build_content(message_details.message, message_details.project_name)
         attachments = self._process_attachments(message_details.attachments)
 
         #: Build message object and send it
@@ -272,7 +272,7 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
 
         return subject
 
-    def _build_content(self, message_details):  #pylint: disable=no-self-use
+    def _build_content(self, message, project_name):  #pylint: disable=no-self-use
         """Add client version if desired and package into plaintext Content object
 
         Args:
@@ -281,13 +281,12 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
         Returns:
             Content: Content of email as a SendGrid Content object
         """
-        message = message_details.message
 
         #: Get the client's version (assuming client has been installed via pip install and setup.py)
-        distributions = pkg_resources.require(message_details.project_name)
+        distributions = pkg_resources.require(project_name)
         if distributions:
             version = distributions[0].version
-            version = f'\n\n{message_details.project_name} version: {version}'
+            version = f'\n\n{project_name} version: {version}'
             message += version
 
         return Content('text/plain', message)

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -182,7 +182,7 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
 
     def __init__(self, sendgrid_settings):
         self.sendgrid_settings = sendgrid_settings
-        self.sendgrid_client = sendgrid.SendGridAPIClient(api_key=self.sendgrid_settings['SENDGRID_API_KEY'])
+        self.sendgrid_client = sendgrid.SendGridAPIClient(api_key=self.sendgrid_settings['api_key'])
 
     def send_message(self, message_details):
         """Construct and send an email message with the SendGrid API

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -292,6 +292,25 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
 
         return Content('text/plain', message)
 
+    def _verify_attachments(self, attachments):
+        error_message = ''
+        good_attachments = []
+        for attachment in attachments:
+            try:
+                attachment_path = Path(attachment)
+                if not attachment_path.exists():
+                    error_message += f'* Attachment "{attachment}" does not exist\n'
+                    continue
+                good_attachments.append(attachment)
+            except TypeError as e:  # pylint: disable=invalid-name
+                if 'expected str, bytes or os.PathLike object, not' in str(e):
+                    error_message += f'* Cannot get Path() of attachment "{attachment}"\n'
+
+        if error_message:
+            error_message = f'{"="*20}\n Supervisor Warning\n{"="*20}\n{error_message}{"="*20}\n\n'
+
+        return error_message, good_attachments
+
     def _process_attachments(self, attachments):
 
         attachment_objects = []

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -207,7 +207,7 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
 
         return from_address, to_addresses
 
-    def _build_recipient_addresses(self, to_addresses):
+    def _build_recipient_addresses(self, to_addresses):  #pylint: disable=no-self-use
         #: If we just get a string just return that one
         if isinstance(to_addresses, str):
             return [To(to_addresses)]
@@ -225,7 +225,7 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
 
         return subject
 
-    def _build_content(self, message_details):
+    def _build_content(self, message_details):  #pylint: disable=no-self-use
         message = message_details.message
 
         #: Get the client's version (assuming client has been installed via pip install and setup.py)

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from smtplib import SMTP
 
 import pkg_resources
+import sendgrid
+from sendgrid.helpers.mail import Attachment, Content, Email, Mail, To
 
 
 class MessageHandler(ABC):  # pylint: disable=too-few-public-methods
@@ -161,6 +163,24 @@ class EmailHandler(MessageHandler):  # pylint: disable=too-few-public-methods
             attachment.add_header('Content-Disposition', f'attachment; filename="{attachment_filename}"')
 
             return attachment
+
+
+class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
+
+    def __init__(self, sendgrid_settings):
+        self.sendgrid_settings = sendgrid_settings
+
+    def send_message(self, message_details):
+        pass
+
+    def _build_message(self, message_details):
+        pass
+
+    def _build_attachements(self, files):
+        pass
+
+    def _zip_files(self, files):
+        pass
 
 
 class SlackHandler(MessageHandler):  # pylint: disable=too-few-public-methods

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -59,8 +59,9 @@ class EmailHandler(MessageHandler):  # pylint: disable=too-few-public-methods
         gzip input_path into a MIMEApplication object
     """
 
-    def __init__(self, email_settings):
+    def __init__(self, email_settings, project_name=''):
         self.email_settings = email_settings
+        self.project_name = project_name
 
     def send_message(self, message_details):
         """Build a message, create an SMTP object, and send the message
@@ -113,10 +114,10 @@ class EmailHandler(MessageHandler):  # pylint: disable=too-few-public-methods
         message.attach(MIMEText(message_details.message, 'html'))
 
         #: Get the client's version (assuming client has been installed via pip install and setup.py)
-        distributions = pkg_resources.require(message_details.project_name)
+        distributions = pkg_resources.require(self.project_name)
         if distributions:
             version = distributions[0].version
-            version = MIMEText(f'<p>{message_details.project_name} version: {version}</p>', 'html')
+            version = MIMEText(f'<p>{self.project_name} version: {version}</p>', 'html')
             message.attach(version)
 
         #: Split recipient addresses if needed.

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -206,8 +206,10 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
         recipient_addresses = self._build_recipient_addresses(to_addresses)
 
         subject = self._build_subject(message_details)
-        content = self._build_content(message_details.message, message_details.project_name)
-        attachments = self._process_attachments(message_details.attachments)
+        attachment_warning, verified_attachments = self._verify_attachments(message_details.attachments)
+        new_message = attachment_warning + message_details.message
+        content = self._build_content(new_message, message_details.project_name)
+        attachments = self._process_attachments(verified_attachments)
 
         #: Build message object and send it
         mail = Mail(sender_address, recipient_addresses, subject, content)

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -259,10 +259,7 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
         if isinstance(to_addresses, str):
             return [To(to_addresses)]
 
-        recipient_addresses = []
-        for address in to_addresses:
-            recipient_addresses.append(To(address))
-        return recipient_addresses
+        return [To(address) for address in to_addresses]
 
     def _build_subject(self, message_details):
         """Add prefix to subject if needed

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -214,7 +214,7 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
         #: Build message object and send it
         mail = Mail(sender_address, recipient_addresses, subject, content)
         mail.attachment = attachments
-        response = self.sendgrid_client.client.mail.send.post(request_body=mail.get())
+        response = self.sendgrid_client.client.mail.send.post(request_body=mail.get())  # pylint: disable=unused-variable
 
         #: Maybe test the response via response.status_code?
 
@@ -293,7 +293,7 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
 
         return Content('text/plain', message)
 
-    def _verify_attachments(self, attachments):
+    def _verify_attachments(self, attachments):  #pylint: disable=no-self-use
         """Make sure attachments are legitimate Paths
 
         Args:
@@ -337,7 +337,7 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
 
         return attachment_objects
 
-    def _zip_whole_directory(self, working_dir, dir_to_be_zipped):
+    def _zip_whole_directory(self, working_dir, dir_to_be_zipped):  #pylint: disable=no-self-use
 
         #: Zip a whole directory to the tempdir, return its path
         attachment_dir = Path(dir_to_be_zipped)
@@ -345,7 +345,7 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
         zip_out_path = make_archive(zip_base_name, 'zip', root_dir=attachment_dir.parent, base_dir=attachment_dir.name)
         return zip_out_path
 
-    def _zip_single_file(self, working_dir, attachment):
+    def _zip_single_file(self, working_dir, attachment):  #pylint: disable=no-self-use
 
         #: Zip a single file to the tempdir, return its path
         attachment_path = Path(attachment)
@@ -354,7 +354,7 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
             new_zip.write(attachment_path, attachment_path.name)
         return zip_out_path
 
-    def _build_attachment(self, zip_path):
+    def _build_attachment(self, zip_path):  #pylint: disable=no-self-use
 
         #: Build a SendGrid Attachment object with various fields
         with open(zip_path, 'rb') as zip_file:

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -204,7 +204,10 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
         return from_address, to_addresses
 
     def _build_recipient_addresses(self, to_addresses):
-        #: Build list of to addresses
+        #: If we just get a string just return that one
+        if isinstance(to_addresses, str):
+            return [To(to_addresses)]
+
         recipient_addresses = []
         for address in to_addresses:
             recipient_addresses.append(To(address))

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -10,6 +10,7 @@ from base64 import b64encode
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from os import stat
 from pathlib import Path
 from shutil import make_archive
 from smtplib import SMTP
@@ -147,7 +148,8 @@ class EmailHandler(MessageHandler):  # pylint: disable=too-few-public-methods
 
         return message
 
-    def _build_gzip_attachment(self, input_path):  #pylint: disable=no-self-use
+    @staticmethod
+    def _build_gzip_attachment(input_path):
         """gzip input_path into a MIMEApplication object
 
         Parameters
@@ -245,7 +247,8 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
 
         return from_address, to_addresses
 
-    def _build_recipient_addresses(self, to_addresses):  #pylint: disable=no-self-use
+    @staticmethod
+    def _build_recipient_addresses(to_addresses):
         """Craft 'to' addresses into a list of SendGrid 'To' objects
 
         Args:
@@ -277,7 +280,8 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
 
         return subject
 
-    def _build_content(self, message, project_name):  #pylint: disable=no-self-use
+    @staticmethod
+    def _build_content(message, project_name):
         """Add client version if desired and package into plaintext Content object
 
         Args:
@@ -297,7 +301,8 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
 
         return Content('text/plain', message)
 
-    def _verify_attachments(self, attachments):  #pylint: disable=no-self-use
+    @staticmethod
+    def _verify_attachments(attachments):
         """Make sure attachments are legitimate Paths
 
         Args:
@@ -349,7 +354,8 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
 
         return attachment_objects
 
-    def _zip_whole_directory(self, working_dir, dir_to_be_zipped):  #pylint: disable=no-self-use
+    @staticmethod
+    def _zip_whole_directory(working_dir, dir_to_be_zipped):
         """Create a zipfile containing a directory and all its contents
 
         Args:
@@ -365,7 +371,8 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
         zip_out_path = make_archive(zip_base_name, 'zip', root_dir=attachment_dir.parent, base_dir=attachment_dir.name)
         return zip_out_path
 
-    def _zip_single_file(self, working_dir, attachment):  #pylint: disable=no-self-use
+    @staticmethod
+    def _zip_single_file(working_dir, attachment):
         """Create a zipfile containing a single file
 
         Args:
@@ -381,7 +388,8 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
             new_zip.write(attachment_path, attachment_path.name)
         return zip_out_path
 
-    def _build_attachment(self, zip_path):  #pylint: disable=no-self-use
+    @staticmethod
+    def _build_attachment(zip_path):
         """Create an Attachment object by base64-encoding the specified file-like object
 
         Args:

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -184,9 +184,10 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
         Build a message and send using the SendGrid API's helper classes
     """
 
-    def __init__(self, sendgrid_settings):
+    def __init__(self, sendgrid_settings, project_name=''):
         self.sendgrid_settings = sendgrid_settings
         self.sendgrid_client = sendgrid.SendGridAPIClient(api_key=self.sendgrid_settings['api_key'])
+        self.project_name = project_name
 
     def send_message(self, message_details):
         """Construct and send an email message with the SendGrid API
@@ -208,7 +209,7 @@ class SendGridHandler(MessageHandler):  # pylint: disable=too-few-public-methods
         subject = self._build_subject(message_details)
         attachment_warning, verified_attachments = self._verify_attachments(message_details.attachments)
         new_message = attachment_warning + message_details.message
-        content = self._build_content(new_message, message_details.project_name)
+        content = self._build_content(new_message, self.project_name)
         attachments = self._process_attachments(verified_attachments)
 
         #: Build message object and send it

--- a/src/supervisor/message_handlers.py
+++ b/src/supervisor/message_handlers.py
@@ -10,7 +10,6 @@ from base64 import b64encode
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from os import stat
 from pathlib import Path
 from shutil import make_archive
 from smtplib import SMTP

--- a/src/supervisor/models.py
+++ b/src/supervisor/models.py
@@ -119,6 +119,23 @@ class MessageDetails:  # pylint: disable=too-few-public-methods
 
     def __init__(self):
         self.message = ''
-        self.attachments = []  #: Strings or Paths
+        self._attachments = []  #: Strings or Paths
         self.subject = ''
         self.project_name = ''
+
+    @property
+    def attachments(self):
+        """List of paths of files to attach
+
+        Returns:
+            List: Attachment paths
+        """
+        return self._attachments
+
+    @attachments.setter
+    def attachments(self, value):
+        if isinstance(value, list):
+            self._attachments.extend(value)
+
+        else:
+            self._attachments.append(value)

--- a/src/supervisor/models.py
+++ b/src/supervisor/models.py
@@ -33,10 +33,9 @@ class Supervisor:
         Closure around a replacement for sys.excepthook
     """
 
-    def __init__(self, project_name, logger=None, log_path=None):
+    def __init__(self, logger=None, log_path=None):
 
         #: Set up our list of MessageHandlers
-        self.project_name = project_name
         self.message_handlers = []
         self.logger = logger
         self.log_path = log_path
@@ -94,7 +93,6 @@ class Supervisor:
             message_details.message = error
             message_details.subject = 'ERROR'
             message_details.attachments = [self.log_path]
-            message_details.project_name = self.project_name
             self.notify(message_details)
 
         return global_exception_handler
@@ -111,8 +109,6 @@ class MessageDetails:  # pylint: disable=too-few-public-methods
         Strings or Paths to any attachments, including log files
     subject : str
         The message subject
-    project_name : str
-        The name of the project that has added the Supervisor object. Used for adding the version to notifications.
 
     TODO: Implement true Null-Object pattern.
     """
@@ -121,7 +117,6 @@ class MessageDetails:  # pylint: disable=too-few-public-methods
         self.message = ''
         self._attachments = []  #: Strings or Paths
         self.subject = ''
-        self.project_name = ''
 
     @property
     def attachments(self):

--- a/src/supervisor/models.py
+++ b/src/supervisor/models.py
@@ -14,8 +14,6 @@ class Supervisor:
 
     Attributes
     ----------
-    project_name : str
-        The name of the client project using Supervisor; used to report version in global exception handler messages
     message_handlers : [MessageHandler]
         Notifications will be sent via all handlers in this list
     logger : Logger

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,6 +1,7 @@
 import pytest
+import sendgrid
 
-from supervisor import message_handlers
+from supervisor import message_handlers, models
 from supervisor.models import MessageDetails
 
 
@@ -397,3 +398,172 @@ def test_send_message_catches_blank_to_address(mocker):
         email_handler.send_message(details)
 
     builder_mock.assert_not_called()
+
+
+class TestSendGridHandlerParts:
+
+    def test_verify_addresses_normal(self, mocker):
+        sendgrid_mock = mocker.Mock()
+        sendgrid_mock.sendgrid_settings = {'from_address': 'foo@bar.com', 'to_addresses': 'cheddar@baz.com'}
+        from_addr, to_addr = message_handlers.SendGridHandler._verify_addresses(sendgrid_mock)
+        assert from_addr == 'foo@bar.com'
+        assert to_addr == 'cheddar@baz.com'
+
+    def test_verify_addresses_no_to_address(self, mocker):
+        sendgrid_mock = mocker.Mock()
+        sendgrid_mock.sendgrid_settings = {'from_address': 'foo@bar.com'}
+        with pytest.warns(UserWarning, match='To/From address settings do not exist. No emails sent.'):
+            from_addr, _ = message_handlers.SendGridHandler._verify_addresses(sendgrid_mock)
+            assert from_addr is None
+
+    def test_verify_addresses_no_from_address(self, mocker):
+        sendgrid_mock = mocker.Mock()
+        sendgrid_mock.sendgrid_settings = {'to_addresses': 'foo@bar.com'}
+        with pytest.warns(UserWarning, match='To/From address settings do not exist. No emails sent.'):
+            _, to_addr = message_handlers.SendGridHandler._verify_addresses(sendgrid_mock)
+            assert to_addr is None
+
+    def test_verify_addresses_empty_from_address(self, mocker):
+        sendgrid_mock = mocker.Mock()
+        sendgrid_mock.sendgrid_settings = {
+            'from_address': '',
+            'to_addresses': 'foo@bar.com',
+        }
+        with pytest.warns(UserWarning, match='To/From address settings exist but are empty. No emails sent.'):
+            from_addr, _ = message_handlers.SendGridHandler._verify_addresses(sendgrid_mock)
+            assert from_addr is None
+
+    def test_verify_addresses_empty_to_address(self, mocker):
+        sendgrid_mock = mocker.Mock()
+        sendgrid_mock.sendgrid_settings = {
+            'from_address': 'foo@bar.com',
+            'to_addresses': '',
+        }
+        with pytest.warns(UserWarning, match='To/From address settings exist but are empty. No emails sent.'):
+            _, to_addr = message_handlers.SendGridHandler._verify_addresses(sendgrid_mock)
+            assert to_addr is None
+
+    def test_build_recipient_addresses_one_addr(self, mocker):
+        sendgrid_mock = mocker.Mock()
+        to_addr = 'foo@bar.com'
+        recipient_list = message_handlers.SendGridHandler._build_recipient_addresses(sendgrid_mock, to_addr)
+        assert len(recipient_list) == 1
+        assert recipient_list[0].email == 'foo@bar.com'
+
+    def test_build_recipient_addresses_multiple_addrs(self, mocker):
+        sendgrid_mock = mocker.Mock()
+        to_addr = ['foo@bar.com', 'cheddar@baz.com']
+        recipient_list = message_handlers.SendGridHandler._build_recipient_addresses(sendgrid_mock, to_addr)
+        assert len(recipient_list) == 2
+        assert recipient_list[0].email == 'foo@bar.com'
+        assert recipient_list[1].email == 'cheddar@baz.com'
+
+    def test_build_subject_no_prefix(self, mocker):
+        sendgrid_mock = mocker.Mock()
+        sendgrid_mock.sendgrid_settings = {}
+        message_details = models.MessageDetails()
+        message_details.subject = 'Foo Subject'
+        subject = message_handlers.SendGridHandler._build_subject(sendgrid_mock, message_details)
+        assert subject == 'Foo Subject'
+
+    def test_build_subject_add_prefix(self, mocker):
+        sendgrid_mock = mocker.Mock()
+        sendgrid_mock.sendgrid_settings = {}
+        sendgrid_mock.sendgrid_settings['prefix'] = 'Bar Prefix—'
+        message_details = models.MessageDetails()
+        message_details.subject = 'Foo Subject'
+        subject = message_handlers.SendGridHandler._build_subject(sendgrid_mock, message_details)
+        assert subject == 'Bar Prefix—Foo Subject'
+
+    def test_build_content_with_version(self, mocker):
+        sendgrid_mock = mocker.Mock()
+
+        distribution_Mock = mocker.Mock()
+        distribution_Mock.version = 0
+        distributions = [distribution_Mock]
+        mocker.patch('pkg_resources.require', return_value=distributions)
+
+        message_details = models.MessageDetails()
+        message_details.message = 'This is a\nmessage with newlines'
+        message_details.project_name = 'ProFoo'
+
+        content_object = message_handlers.SendGridHandler._build_content(sendgrid_mock, message_details)
+        assert content_object.content == 'This is a\nmessage with newlines\n\nProFoo version: 0'
+        assert content_object.mime_type == 'text/plain'
+
+    def test_build_content_without_version(self, mocker):
+        sendgrid_mock = mocker.Mock()
+
+        mocker.patch('pkg_resources.require', return_value=[])
+
+        message_details = models.MessageDetails()
+        message_details.message = 'This is a\nmessage with newlines'
+        message_details.project_name = 'ProFoo'
+
+        content_object = message_handlers.SendGridHandler._build_content(sendgrid_mock, message_details)
+        assert content_object.content == 'This is a\nmessage with newlines'
+        assert content_object.mime_type == 'text/plain'
+
+
+class TestSandGridHandlerWhole:
+
+    def test_send_message_blank_to_addr(self, mocker):
+
+        sendgrid_settings = {
+            'from_address': 'foo@bar.com',
+            'to_addresses': '',
+            'SENDGRID_API_KEY': 'itsasecret',
+        }
+        recipient_mock = mocker.patch.object(message_handlers.SendGridHandler, '_build_recipient_addresses')
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+
+        message_details = models.MessageDetails()
+
+        with pytest.warns(UserWarning, match='To/From address settings exist but are empty. No emails sent.'):
+            sendgrid_handler.send_message(message_details)
+            recipient_mock.assert_not_called()
+
+    def test_send_message_blank_from_addr(self, mocker):
+
+        sendgrid_settings = {
+            'from_address': '',
+            'to_addresses': 'foo@bar.com',
+            'SENDGRID_API_KEY': 'itsasecret',
+        }
+        recipient_mock = mocker.patch.object(message_handlers.SendGridHandler, '_build_recipient_addresses')
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+
+        message_details = models.MessageDetails()
+
+        with pytest.warns(UserWarning, match='To/From address settings exist but are empty. No emails sent.'):
+            sendgrid_handler.send_message(message_details)
+            recipient_mock.assert_not_called()
+
+    def test_send_message_full_integration_with_version(self, mocker):
+
+        sg_api_mock = mocker.patch('sendgrid.SendGridAPIClient')
+
+        distribution_Mock = mocker.Mock()
+        distribution_Mock.version = 3.14
+        distributions = [distribution_Mock]
+        mocker.patch('pkg_resources.require', return_value=distributions)
+
+        sendgrid_settings = {
+            'from_address': 'foo@example.com',
+            'to_addresses': 'cheddar@example.com',
+            'SENDGRID_API_KEY': 'itsasecret',
+        }
+
+        message_details = models.MessageDetails()
+        message_details.message = 'This is a\nmulti-line\nmessage'
+        message_details.project_name = 'ProFoo'
+
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+
+        sendgrid_handler.send_message(message_details)
+
+        request_body = sendgrid_handler.sendgrid_client.client.mail.send.post.call_args[1]['request_body']
+        assert request_body['from']['email'] == 'foo@example.com'
+        assert request_body['personalizations'][0]['to'][0]['email'] == 'cheddar@example.com'
+        assert request_body['content'][0]['type'] == 'text/plain'
+        assert request_body['content'][0]['value'] == 'This is a\nmulti-line\nmessage\n\nProFoo version: 3.14'

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -512,6 +512,75 @@ class TestSendGridHandlerParts:
         assert content_object.content == 'This is a\nmessage with newlines'
         assert content_object.mime_type == 'text/plain'
 
+    def test_verify_attachments_bad_Path_input(self, mocker):
+        sendgrid_mock = mocker.Mock()
+        attachments = [3]
+
+        error_message, attachments = message_handlers.SendGridHandler._verify_attachments(sendgrid_mock, attachments)
+
+        assert 'Cannot get Path() of attachment' in error_message
+        assert attachments == []
+
+    def test_verify_attachments_Path_does_not_exist(self, mocker, tmp_path):
+        bad_path = tmp_path / 'bad.txt'
+
+        sendgrid_mock = mocker.Mock()
+        attachments = [bad_path]
+
+        error_message, attachments = message_handlers.SendGridHandler._verify_attachments(sendgrid_mock, attachments)
+
+        assert 'does not exist' in error_message
+        assert attachments == []
+
+    def test_verify_attachments_good_Path(self, mocker, tmp_path):
+        good_path = tmp_path / 'a.txt'
+        good_path.write_text('a')
+
+        sendgrid_mock = mocker.Mock()
+        attachments = [good_path]
+
+        error_message, attachments = message_handlers.SendGridHandler._verify_attachments(sendgrid_mock, attachments)
+
+        assert error_message == ''
+        assert attachments == [Path(good_path)]
+
+    def test_verify_attachments_good_Path_and_bad_Path_input(self, mocker, tmp_path):
+        good_path = tmp_path / 'a.txt'
+        good_path.write_text('a')
+
+        sendgrid_mock = mocker.Mock()
+        attachments = [good_path, 3]
+
+        error_message, attachments = message_handlers.SendGridHandler._verify_attachments(sendgrid_mock, attachments)
+
+        assert 'Cannot get Path() of attachment' in error_message
+        assert attachments == [Path(good_path)]
+
+    def test_verify_attachments_good_Path_and_Path_not_exist(self, mocker, tmp_path):
+        good_path = tmp_path / 'a.txt'
+        good_path.write_text('a')
+        bad_path = tmp_path / 'b.txt'
+
+        sendgrid_mock = mocker.Mock()
+        attachments = [good_path, bad_path]
+
+        error_message, attachments = message_handlers.SendGridHandler._verify_attachments(sendgrid_mock, attachments)
+
+        assert 'does not exist' in error_message
+        assert attachments == [Path(good_path)]
+
+    def test_verify_attachments_bad_Path_input_and_Path_not_exist(self, mocker, tmp_path):
+        bad_path = tmp_path / 'b.txt'
+
+        sendgrid_mock = mocker.Mock()
+        attachments = [3, bad_path]
+
+        error_message, attachments = message_handlers.SendGridHandler._verify_attachments(sendgrid_mock, attachments)
+
+        assert 'does not exist' in error_message
+        assert 'Cannot get Path() of attachment' in error_message
+        assert attachments == []
+
 
 class TestSendGridHandlerWhole:
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -637,9 +637,9 @@ class TestSendGridHandlerWhole:
 
         message_details = models.MessageDetails()
         message_details.message = 'This is a\nmulti-line\nmessage'
-        message_details.project_name = 'ProFoo'
+        # message_details.project_name = 'ProFoo'
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
 
         sendgrid_handler.send_message(message_details)
 
@@ -671,10 +671,10 @@ class TestSendGridHandlerWhole:
 
         message_details = models.MessageDetails()
         message_details.message = 'This is a\nmulti-line\nmessage'
-        message_details.project_name = 'ProFoo'
+        # message_details.project_name = 'ProFoo'
         message_details.attachments = [temp_a]
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
 
         sendgrid_handler.send_message(message_details)
 
@@ -710,10 +710,10 @@ class TestSendGridHandlerWhole:
 
         message_details = models.MessageDetails()
         message_details.message = 'This is a\nmulti-line\nmessage'
-        message_details.project_name = 'ProFoo'
+        # message_details.project_name = 'ProFoo'
         message_details.attachments = [dir_to_be_attached]
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
 
         sendgrid_handler.send_message(message_details)
 
@@ -753,10 +753,10 @@ class TestSendGridHandlerWhole:
 
         message_details = models.MessageDetails()
         message_details.message = 'This is a\nmulti-line\nmessage'
-        message_details.project_name = 'ProFoo'
+        # message_details.project_name = 'ProFoo'
         message_details.attachments = [dir_to_be_attached, single_file]
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
 
         sendgrid_handler.send_message(message_details)
 
@@ -798,10 +798,10 @@ class TestSendGridHandlerWhole:
 
         message_details = models.MessageDetails()
         message_details.message = 'This is a\nmulti-line\nmessage'
-        message_details.project_name = 'ProFoo'
+        # message_details.project_name = 'ProFoo'
         message_details.attachments = [single_file, dir_to_be_attached]
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
 
         sendgrid_handler.send_message(message_details)
 
@@ -833,10 +833,10 @@ class TestSendGridHandlerWhole:
 
         message_details = models.MessageDetails()
         message_details.message = 'This is a\nmulti-line\nmessage'
-        message_details.project_name = 'ProFoo'
+        # message_details.project_name = 'ProFoo'
         message_details.attachments = [bad_file]
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
 
         sendgrid_handler.send_message(message_details)
 
@@ -865,10 +865,10 @@ class TestSendGridHandlerWhole:
 
         message_details = models.MessageDetails()
         message_details.message = 'This is a\nmulti-line\nmessage'
-        message_details.project_name = 'ProFoo'
+        # message_details.project_name = 'ProFoo'
         message_details.attachments = [3]
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
 
         sendgrid_handler.send_message(message_details)
 
@@ -900,10 +900,10 @@ class TestSendGridHandlerWhole:
 
         message_details = models.MessageDetails()
         message_details.message = 'This is a\nmulti-line\nmessage'
-        message_details.project_name = 'ProFoo'
+        # message_details.project_name = 'ProFoo'
         message_details.attachments = [good_file, 3]
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
 
         sendgrid_handler.send_message(message_details)
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,5 +1,11 @@
+import base64
+import zipfile
+from base64 import b64encode
+from unittest import mock
+
 import pytest
 import sendgrid
+from sendgrid.helpers.mail import attachment
 
 from supervisor import message_handlers, models
 from supervisor.models import MessageDetails
@@ -505,7 +511,7 @@ class TestSendGridHandlerParts:
         assert content_object.mime_type == 'text/plain'
 
 
-class TestSandGridHandlerWhole:
+class TestSendGridHandlerWhole:
 
     def test_send_message_blank_to_addr(self, mocker):
 
@@ -567,3 +573,300 @@ class TestSandGridHandlerWhole:
         assert request_body['personalizations'][0]['to'][0]['email'] == 'cheddar@example.com'
         assert request_body['content'][0]['type'] == 'text/plain'
         assert request_body['content'][0]['value'] == 'This is a\nmulti-line\nmessage\n\nProFoo version: 3.14'
+        assert 'attachments' not in request_body
+
+    def test_send_message_full_integration_with_single_file_attachment(self, mocker, tmp_path):
+
+        sg_api_mock = mocker.patch('sendgrid.SendGridAPIClient')
+
+        distribution_Mock = mocker.Mock()
+        distribution_Mock.version = 3.14
+        distributions = [distribution_Mock]
+        mocker.patch('pkg_resources.require', return_value=distributions)
+
+        sendgrid_settings = {
+            'from_address': 'foo@example.com',
+            'to_addresses': 'cheddar@example.com',
+            'api_key': 'itsasecret',
+        }
+
+        att_path = tmp_path
+        temp_a = att_path / 'single.txt'
+        temp_a.write_text('single')
+
+        message_details = models.MessageDetails()
+        message_details.message = 'This is a\nmulti-line\nmessage'
+        message_details.project_name = 'ProFoo'
+        message_details.attachments = [temp_a]
+
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+
+        sendgrid_handler.send_message(message_details)
+
+        request_body = sendgrid_handler.sendgrid_client.client.mail.send.post.call_args[1]['request_body']
+        assert request_body['from']['email'] == 'foo@example.com'
+        assert request_body['personalizations'][0]['to'][0]['email'] == 'cheddar@example.com'
+        assert request_body['content'][0]['type'] == 'text/plain'
+        assert request_body['content'][0]['value'] == 'This is a\nmulti-line\nmessage\n\nProFoo version: 3.14'
+        assert request_body['attachments'][0]['filename'] == temp_a.with_suffix('.zip').name
+
+    def test_send_message_full_integration_with_directory_attachment(self, mocker, tmp_path):
+
+        sg_api_mock = mocker.patch('sendgrid.SendGridAPIClient')
+
+        distribution_Mock = mocker.Mock()
+        distribution_Mock.version = 3.14
+        distributions = [distribution_Mock]
+        mocker.patch('pkg_resources.require', return_value=distributions)
+
+        sendgrid_settings = {
+            'from_address': 'foo@example.com',
+            'to_addresses': 'cheddar@example.com',
+            'api_key': 'itsasecret',
+        }
+
+        working_dir = tmp_path
+        dir_to_be_attached = working_dir / 'zipme'
+        dir_to_be_attached.mkdir()
+        temp_a = dir_to_be_attached / 'a.txt'
+        temp_a.write_text('a')
+        temp_b = dir_to_be_attached / 'b.txt'
+        temp_b.write_text('b')
+
+        message_details = models.MessageDetails()
+        message_details.message = 'This is a\nmulti-line\nmessage'
+        message_details.project_name = 'ProFoo'
+        message_details.attachments = [dir_to_be_attached]
+
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+
+        sendgrid_handler.send_message(message_details)
+
+        request_body = sendgrid_handler.sendgrid_client.client.mail.send.post.call_args[1]['request_body']
+        assert request_body['from']['email'] == 'foo@example.com'
+        assert request_body['personalizations'][0]['to'][0]['email'] == 'cheddar@example.com'
+        assert request_body['content'][0]['type'] == 'text/plain'
+        assert request_body['content'][0]['value'] == 'This is a\nmulti-line\nmessage\n\nProFoo version: 3.14'
+        assert request_body['attachments'][0]['filename'] == dir_to_be_attached.with_suffix('.zip').name
+
+    def test_send_message_full_integration_with_single_file_and_directory_attachments(self, mocker, tmp_path):
+
+        sg_api_mock = mocker.patch('sendgrid.SendGridAPIClient')
+
+        distribution_Mock = mocker.Mock()
+        distribution_Mock.version = 3.14
+        distributions = [distribution_Mock]
+        mocker.patch('pkg_resources.require', return_value=distributions)
+
+        sendgrid_settings = {
+            'from_address': 'foo@example.com',
+            'to_addresses': 'cheddar@example.com',
+            'api_key': 'itsasecret',
+        }
+
+        working_dir = tmp_path
+
+        single_file = working_dir / 'single.txt'
+        single_file.write_text('single')
+
+        dir_to_be_attached = working_dir / 'zipme'
+        dir_to_be_attached.mkdir()
+        temp_a = dir_to_be_attached / 'a.txt'
+        temp_a.write_text('a')
+        temp_b = dir_to_be_attached / 'b.txt'
+        temp_b.write_text('b')
+
+        message_details = models.MessageDetails()
+        message_details.message = 'This is a\nmulti-line\nmessage'
+        message_details.project_name = 'ProFoo'
+        message_details.attachments = [dir_to_be_attached, single_file]
+
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+
+        sendgrid_handler.send_message(message_details)
+
+        request_body = sendgrid_handler.sendgrid_client.client.mail.send.post.call_args[1]['request_body']
+        assert request_body['from']['email'] == 'foo@example.com'
+        assert request_body['personalizations'][0]['to'][0]['email'] == 'cheddar@example.com'
+        assert request_body['content'][0]['type'] == 'text/plain'
+        assert request_body['content'][0]['value'] == 'This is a\nmulti-line\nmessage\n\nProFoo version: 3.14'
+        attachment_names = [att['filename'] for att in request_body['attachments']]
+        # assert request_body['attachments'][0]['filename'] == dir_to_be_attached.with_suffix('.zip').name
+        # assert request_body['attachments'][1]['filename'] == single_file.with_suffix('.zip').name
+        assert dir_to_be_attached.with_suffix('.zip').name in attachment_names
+        assert single_file.with_suffix('.zip').name in attachment_names
+
+
+class TestSendGridHandlerAttachments:
+
+    def test_process_attachments_single_file(self, mocker, tmp_path):
+        temp_file = tmp_path / 'test.txt'
+        temp_file.write_text('test_process_attachments_single_file')
+
+        def _build_attachment_side_effect(value):
+            return value
+
+        sendgrid_mock = mocker.Mock()
+        sendgrid_mock._zip_whole_directory.return_value = 'directory call'
+        sendgrid_mock._zip_single_file.return_value = 'single file call'
+        sendgrid_mock._build_attachment.side_effect = _build_attachment_side_effect
+
+        attachments = message_handlers.SendGridHandler._process_attachments(sendgrid_mock, [temp_file])
+
+        sendgrid_mock._zip_whole_directory.assert_not_called()
+        sendgrid_mock._zip_single_file.assert_called_once()
+        assert attachments == ['single file call']
+
+    def test_process_attachments_directory(self, mocker, tmp_path):
+
+        def _build_attachment_side_effect(value):
+            return value
+
+        sendgrid_mock = mocker.Mock()
+        sendgrid_mock._zip_whole_directory.return_value = 'directory call'
+        sendgrid_mock._zip_single_file.return_value = 'single file call'
+        sendgrid_mock._build_attachment.side_effect = _build_attachment_side_effect
+
+        attachments = message_handlers.SendGridHandler._process_attachments(sendgrid_mock, [tmp_path])
+
+        sendgrid_mock._zip_whole_directory.assert_called_once()
+        sendgrid_mock._zip_single_file.assert_not_called()
+        assert attachments == ['directory call']
+
+    def test_process_attachments_dispatches_both_file_and_directory(self, mocker, tmp_path):
+        temp_file = tmp_path / 'test.txt'
+        temp_file.write_text('test_process_attachments_single_file')
+
+        def _build_attachment_side_effect(value):
+            return value
+
+        sendgrid_mock = mocker.Mock()
+        sendgrid_mock._zip_whole_directory.return_value = 'directory call'
+        sendgrid_mock._zip_single_file.return_value = 'single file call'
+        sendgrid_mock._build_attachment.side_effect = _build_attachment_side_effect
+
+        attachments = message_handlers.SendGridHandler._process_attachments(sendgrid_mock, [temp_file, tmp_path])
+
+        sendgrid_mock._zip_whole_directory.assert_called_once()
+        sendgrid_mock._zip_single_file.assert_called_once()
+        assert attachments == ['single file call', 'directory call']
+
+    def test_process_attachments_no_attachments(self, mocker):
+        sendgrid_mock = mocker.Mock()
+        sendgrid_mock._zip_whole_directory.return_value = 'directory call'
+        sendgrid_mock._zip_single_file.return_value = 'single file call'
+
+        attachments = message_handlers.SendGridHandler._process_attachments(sendgrid_mock, [])
+
+        sendgrid_mock._zip_whole_directory.assert_not_called()
+        sendgrid_mock._zip_single_file.assert_not_called()
+        assert attachments == []
+
+    def test_zip_whole_directory(self, mocker, tmp_path):
+        working_dir = tmp_path
+        dir_to_be_zipped = working_dir / 'zipme'
+        dir_to_be_zipped.mkdir()
+        temp_a = dir_to_be_zipped / 'a.txt'
+        temp_a.write_text('a')
+        temp_b = dir_to_be_zipped / 'b.txt'
+        temp_b.write_text('b')
+
+        sendgrid_mock = mocker.Mock()
+
+        zipped_path = message_handlers.SendGridHandler._zip_whole_directory(
+            sendgrid_mock, working_dir, dir_to_be_zipped
+        )
+
+        assert zipfile.ZipFile(zipped_path).namelist() == ['zipme/', 'zipme/a.txt', 'zipme/b.txt']
+
+    def test_zip_single_file(self, mocker, tmp_path):
+        working_dir = tmp_path
+        temp_a = working_dir / 'a.txt'
+        temp_a.write_text('a')
+
+        sendgrid_mock = mocker.Mock()
+
+        zipped_path = message_handlers.SendGridHandler._zip_single_file(sendgrid_mock, working_dir, temp_a)
+
+        assert zipfile.ZipFile(zipped_path).namelist() == ['a.txt']
+
+    def test_process_attachments_zips_both_single_files_and_directory(self, mocker, tmp_path):
+        working_dir = tmp_path
+        dir_to_be_zipped = working_dir / 'zipme'
+        dir_to_be_zipped.mkdir()
+        temp_a = dir_to_be_zipped / 'a.txt'
+        temp_a.write_text('a')
+        temp_b = dir_to_be_zipped / 'b.txt'
+        temp_b.write_text('b')
+
+        single_file_to_be_zipped = working_dir / 'single.txt'
+        single_file_to_be_zipped.write_text('single file')
+
+        def _build_attachment_side_effect(self_obj, value):
+            return value
+
+        attachment_mock = mocker.patch.object(
+            message_handlers.SendGridHandler, '_build_attachment', _build_attachment_side_effect
+        )
+        sendgrid_settings = {'api_key': 'itsasecret'}
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+
+        attachments = sendgrid_handler._process_attachments([dir_to_be_zipped, single_file_to_be_zipped])
+
+        # assert attachments == [working_dir / 'zipme.zip', working_dir / 'single.zip']
+        assert len(attachments) == 2
+        assert zipfile.ZipFile(attachments[0]).namelist() == ['zipme/', 'zipme/a.txt', 'zipme/b.txt']
+        assert zipfile.ZipFile(attachments[1]).namelist() == ['single.txt']
+
+    def test_build_attachment_mock_file(self, mocker):
+        mock_open = mock.mock_open(read_data=b'test data')
+        sendgrid_mock = mocker.Mock()
+
+        with mock.patch('builtins.open', mock_open):
+            attachment = message_handlers.SendGridHandler._build_attachment(sendgrid_mock, 'foo')
+
+            assert attachment.file_name.get() == 'foo'
+            assert attachment.file_type.get() == 'application/zip'
+            assert attachment.file_content.get() == base64.b64encode(b'test data').decode()
+
+    def test_build_attachment_single_file(self, mocker, tmp_path):
+        working_dir = tmp_path
+        temp_a = working_dir / 'a.txt'
+        temp_a.write_text('a')
+
+        sendgrid_mock = mocker.Mock()
+        single_zip_path = message_handlers.SendGridHandler._zip_single_file(sendgrid_mock, working_dir, temp_a)
+
+        with open(single_zip_path, 'rb') as single_zip_file:
+            data = single_zip_file.read()
+        encoded = b64encode(data).decode()
+
+        attachment = message_handlers.SendGridHandler._build_attachment(sendgrid_mock, single_zip_path)
+
+        assert attachment.file_name.get() == 'a.zip'
+        assert attachment.file_type.get() == 'application/zip'
+        assert attachment.file_content.get() == encoded
+
+    def test_build_attachment_directory(self, mocker, tmp_path):
+        working_dir = tmp_path
+        dir_to_be_zipped = working_dir / 'zipme'
+        dir_to_be_zipped.mkdir()
+        temp_a = dir_to_be_zipped / 'a.txt'
+        temp_a.write_text('a')
+        temp_b = dir_to_be_zipped / 'b.txt'
+        temp_b.write_text('b')
+
+        sendgrid_mock = mocker.Mock()
+        dir_zip_path = message_handlers.SendGridHandler._zip_whole_directory(
+            sendgrid_mock, working_dir, dir_to_be_zipped
+        )
+
+        with open(dir_zip_path, 'rb') as dir_zip_file:
+            data = dir_zip_file.read()
+        encoded = b64encode(data).decode()
+
+        attachment = message_handlers.SendGridHandler._build_attachment(sendgrid_mock, dir_zip_path)
+
+        assert attachment.file_name.get() == 'zipme.zip'
+        assert attachment.file_type.get() == 'application/zip'
+        assert attachment.file_content.get() == encoded

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -512,7 +512,7 @@ class TestSandGridHandlerWhole:
         sendgrid_settings = {
             'from_address': 'foo@bar.com',
             'to_addresses': '',
-            'SENDGRID_API_KEY': 'itsasecret',
+            'api_key': 'itsasecret',
         }
         recipient_mock = mocker.patch.object(message_handlers.SendGridHandler, '_build_recipient_addresses')
         sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
@@ -528,7 +528,7 @@ class TestSandGridHandlerWhole:
         sendgrid_settings = {
             'from_address': '',
             'to_addresses': 'foo@bar.com',
-            'SENDGRID_API_KEY': 'itsasecret',
+            'api_key': 'itsasecret',
         }
         recipient_mock = mocker.patch.object(message_handlers.SendGridHandler, '_build_recipient_addresses')
         sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
@@ -551,7 +551,7 @@ class TestSandGridHandlerWhole:
         sendgrid_settings = {
             'from_address': 'foo@example.com',
             'to_addresses': 'cheddar@example.com',
-            'SENDGRID_API_KEY': 'itsasecret',
+            'api_key': 'itsasecret',
         }
 
         message_details = models.MessageDetails()

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1052,8 +1052,11 @@ class TestSendGridHandlerAttachments:
         zipped_path = message_handlers.SendGridHandler._zip_whole_directory(
             sendgrid_mock, working_dir, dir_to_be_zipped
         )
-
-        assert zipfile.ZipFile(zipped_path).namelist() == ['zipme/', 'zipme/a.txt', 'zipme/b.txt']
+        zip_name_list = zipfile.ZipFile(zipped_path).namelist()
+        assert 'zipme/' in zip_name_list
+        assert 'zipme/a.txt' in zip_name_list
+        assert 'zipme/b.txt' in zip_name_list
+        # assert zipfile.ZipFile(zipped_path).namelist() == ['zipme/', 'zipme/a.txt', 'zipme/b.txt']
 
     def test_zip_single_file(self, mocker, tmp_path):
         working_dir = tmp_path

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -35,13 +35,13 @@ def test_build_message_without_attachments(mocker):
     message_details = MessageDetails()
     message_details.message = 'test_message'
     message_details.subject = 'test_subject'
-    message_details.project_name = 'testing'
 
     handler_mock = mocker.Mock()
     handler_mock.email_settings = {
         'to_addresses': 'foo@example.com',
         'from_address': 'testing@example.com',
     }
+    handler_mock.project_name = 'testing'
 
     test_message = message_handlers.EmailHandler._build_message(handler_mock, message_details)
 
@@ -62,7 +62,6 @@ def test_build_message_with_None_attachment(mocker):
     message_details = MessageDetails()
     message_details.message = 'test_message'
     message_details.subject = 'test_subject'
-    message_details.project_name = 'testing'
     message_details.attachments = [None]
 
     handler_mock = mocker.Mock()
@@ -70,6 +69,7 @@ def test_build_message_with_None_attachment(mocker):
         'to_addresses': 'foo@example.com',
         'from_address': 'testing@example.com',
     }
+    handler_mock.project_name = 'testing'
 
     test_message = message_handlers.EmailHandler._build_message(handler_mock, message_details)
 
@@ -90,7 +90,6 @@ def test_build_message_with_empty_str_attachment_path(mocker):
     message_details = MessageDetails()
     message_details.message = 'test_message'
     message_details.subject = 'test_subject'
-    message_details.project_name = 'testing'
     message_details.attachments = ['']
 
     handler_mock = mocker.Mock()
@@ -98,6 +97,7 @@ def test_build_message_with_empty_str_attachment_path(mocker):
         'to_addresses': 'foo@example.com',
         'from_address': 'testing@example.com',
     }
+    handler_mock.project_name = 'testing'
 
     test_message = message_handlers.EmailHandler._build_message(handler_mock, message_details)
 
@@ -118,7 +118,6 @@ def test_build_message_with_subject_prefix(mocker):
     message_details = MessageDetails()
     message_details.message = 'test_message'
     message_details.subject = 'test_subject'
-    message_details.project_name = 'testing'
 
     handler_mock = mocker.Mock()
     handler_mock.email_settings = {
@@ -126,6 +125,7 @@ def test_build_message_with_subject_prefix(mocker):
         'from_address': 'testing@example.com',
         'prefix': 'test prefix: ',
     }
+    handler_mock.project_name = 'testing'
 
     test_message = message_handlers.EmailHandler._build_message(handler_mock, message_details)
 
@@ -146,13 +146,13 @@ def test_build_message_with_multiple_to_addresses(mocker):
     message_details = MessageDetails()
     message_details.message = 'test_message'
     message_details.subject = 'test_subject'
-    message_details.project_name = 'testing'
 
     handler_mock = mocker.Mock()
     handler_mock.email_settings = {
         'to_addresses': ['foo@example.com', 'bar@example.com', 'baz@example.com'],
         'from_address': 'testing@example.com',
     }
+    handler_mock.project_name = 'testing'
 
     test_message = message_handlers.EmailHandler._build_message(handler_mock, message_details)
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -495,7 +495,9 @@ class TestSendGridHandlerParts:
         message_details.message = 'This is a\nmessage with newlines'
         message_details.project_name = 'ProFoo'
 
-        content_object = message_handlers.SendGridHandler._build_content(sendgrid_mock, message_details)
+        content_object = message_handlers.SendGridHandler._build_content(
+            sendgrid_mock, message_details.message, message_details.project_name
+        )
         assert content_object.content == 'This is a\nmessage with newlines\n\nProFoo version: 0'
         assert content_object.mime_type == 'text/plain'
 
@@ -508,7 +510,9 @@ class TestSendGridHandlerParts:
         message_details.message = 'This is a\nmessage with newlines'
         message_details.project_name = 'ProFoo'
 
-        content_object = message_handlers.SendGridHandler._build_content(sendgrid_mock, message_details)
+        content_object = message_handlers.SendGridHandler._build_content(
+            sendgrid_mock, message_details.message, message_details.project_name
+        )
         assert content_object.content == 'This is a\nmessage with newlines'
         assert content_object.mime_type == 'text/plain'
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,6 +1,7 @@
 import base64
 import zipfile
 from base64 import b64encode
+from tempfile import TemporaryDirectory
 from unittest import mock
 
 import pytest
@@ -649,7 +650,7 @@ class TestSendGridHandlerWhole:
         assert request_body['content'][0]['value'] == 'This is a\nmulti-line\nmessage\n\nProFoo version: 3.14'
         assert request_body['attachments'][0]['filename'] == dir_to_be_attached.with_suffix('.zip').name
 
-    def test_send_message_full_integration_with_single_file_and_directory_attachments(self, mocker, tmp_path):
+    def test_send_message_full_integration_with_directory_and_single_file_attachments(self, mocker, tmp_path):
 
         sg_api_mock = mocker.patch('sendgrid.SendGridAPIClient')
 
@@ -696,10 +697,57 @@ class TestSendGridHandlerWhole:
         assert dir_to_be_attached.with_suffix('.zip').name in attachment_names
         assert single_file.with_suffix('.zip').name in attachment_names
 
+    def test_send_message_full_integration_with_single_file_and_directory_attachments(self, mocker, tmp_path):
+
+        sg_api_mock = mocker.patch('sendgrid.SendGridAPIClient')
+
+        distribution_Mock = mocker.Mock()
+        distribution_Mock.version = 3.14
+        distributions = [distribution_Mock]
+        mocker.patch('pkg_resources.require', return_value=distributions)
+
+        sendgrid_settings = {
+            'from_address': 'foo@example.com',
+            'to_addresses': 'cheddar@example.com',
+            'api_key': 'itsasecret',
+        }
+
+        working_dir = tmp_path
+
+        single_file = working_dir / 'single.txt'
+        single_file.write_text('single')
+
+        dir_to_be_attached = working_dir / 'zipme'
+        dir_to_be_attached.mkdir()
+        temp_a = dir_to_be_attached / 'a.txt'
+        temp_a.write_text('a')
+        temp_b = dir_to_be_attached / 'b.txt'
+        temp_b.write_text('b')
+
+        message_details = models.MessageDetails()
+        message_details.message = 'This is a\nmulti-line\nmessage'
+        message_details.project_name = 'ProFoo'
+        message_details.attachments = [single_file, dir_to_be_attached]
+
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+
+        sendgrid_handler.send_message(message_details)
+
+        request_body = sendgrid_handler.sendgrid_client.client.mail.send.post.call_args[1]['request_body']
+        assert request_body['from']['email'] == 'foo@example.com'
+        assert request_body['personalizations'][0]['to'][0]['email'] == 'cheddar@example.com'
+        assert request_body['content'][0]['type'] == 'text/plain'
+        assert request_body['content'][0]['value'] == 'This is a\nmulti-line\nmessage\n\nProFoo version: 3.14'
+        attachment_names = [att['filename'] for att in request_body['attachments']]
+        # assert request_body['attachments'][0]['filename'] == dir_to_be_attached.with_suffix('.zip').name
+        # assert request_body['attachments'][1]['filename'] == single_file.with_suffix('.zip').name
+        assert dir_to_be_attached.with_suffix('.zip').name in attachment_names
+        assert single_file.with_suffix('.zip').name in attachment_names
+
 
 class TestSendGridHandlerAttachments:
 
-    def test_process_attachments_single_file(self, mocker, tmp_path):
+    def test_process_attachments_dispatches_single_file(self, mocker, tmp_path):
         temp_file = tmp_path / 'test.txt'
         temp_file.write_text('test_process_attachments_single_file')
 
@@ -717,7 +765,7 @@ class TestSendGridHandlerAttachments:
         sendgrid_mock._zip_single_file.assert_called_once()
         assert attachments == ['single file call']
 
-    def test_process_attachments_directory(self, mocker, tmp_path):
+    def test_process_attachments_dispatches_directory(self, mocker, tmp_path):
 
         def _build_attachment_side_effect(value):
             return value
@@ -751,7 +799,7 @@ class TestSendGridHandlerAttachments:
         sendgrid_mock._zip_single_file.assert_called_once()
         assert attachments == ['single file call', 'directory call']
 
-    def test_process_attachments_no_attachments(self, mocker):
+    def test_process_attachments_dispatches_no_attachments(self, mocker):
         sendgrid_mock = mocker.Mock()
         sendgrid_mock._zip_whole_directory.return_value = 'directory call'
         sendgrid_mock._zip_single_file.return_value = 'single file call'
@@ -762,35 +810,7 @@ class TestSendGridHandlerAttachments:
         sendgrid_mock._zip_single_file.assert_not_called()
         assert attachments == []
 
-    def test_zip_whole_directory(self, mocker, tmp_path):
-        working_dir = tmp_path
-        dir_to_be_zipped = working_dir / 'zipme'
-        dir_to_be_zipped.mkdir()
-        temp_a = dir_to_be_zipped / 'a.txt'
-        temp_a.write_text('a')
-        temp_b = dir_to_be_zipped / 'b.txt'
-        temp_b.write_text('b')
-
-        sendgrid_mock = mocker.Mock()
-
-        zipped_path = message_handlers.SendGridHandler._zip_whole_directory(
-            sendgrid_mock, working_dir, dir_to_be_zipped
-        )
-
-        assert zipfile.ZipFile(zipped_path).namelist() == ['zipme/', 'zipme/a.txt', 'zipme/b.txt']
-
-    def test_zip_single_file(self, mocker, tmp_path):
-        working_dir = tmp_path
-        temp_a = working_dir / 'a.txt'
-        temp_a.write_text('a')
-
-        sendgrid_mock = mocker.Mock()
-
-        zipped_path = message_handlers.SendGridHandler._zip_single_file(sendgrid_mock, working_dir, temp_a)
-
-        assert zipfile.ZipFile(zipped_path).namelist() == ['a.txt']
-
-    def test_process_attachments_zips_both_single_files_and_directory(self, mocker, tmp_path):
+    def test_process_attachments_zips_both_directory_and_single_file(self, mocker, tmp_path):
         working_dir = tmp_path
         dir_to_be_zipped = working_dir / 'zipme'
         dir_to_be_zipped.mkdir()
@@ -813,10 +833,69 @@ class TestSendGridHandlerAttachments:
 
         attachments = sendgrid_handler._process_attachments([dir_to_be_zipped, single_file_to_be_zipped])
 
-        # assert attachments == [working_dir / 'zipme.zip', working_dir / 'single.zip']
+        #: If we use TemporaryDirectory() as a context manager in _process_attachments, the zip files
+        #: no longer exist for these asserts to check.
         assert len(attachments) == 2
         assert zipfile.ZipFile(attachments[0]).namelist() == ['zipme/', 'zipme/a.txt', 'zipme/b.txt']
         assert zipfile.ZipFile(attachments[1]).namelist() == ['single.txt']
+
+    def test_process_attachments_zips_both_single_file_and_directory(self, mocker, tmp_path):
+        working_dir = tmp_path
+        dir_to_be_zipped = working_dir / 'zipme'
+        dir_to_be_zipped.mkdir()
+        temp_a = dir_to_be_zipped / 'a.txt'
+        temp_a.write_text('a')
+        temp_b = dir_to_be_zipped / 'b.txt'
+        temp_b.write_text('b')
+
+        single_file_to_be_zipped = working_dir / 'single.txt'
+        single_file_to_be_zipped.write_text('single file')
+
+        def _build_attachment_side_effect(self_obj, value):
+            return value
+
+        attachment_mock = mocker.patch.object(
+            message_handlers.SendGridHandler, '_build_attachment', _build_attachment_side_effect
+        )
+        sendgrid_settings = {'api_key': 'itsasecret'}
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings)
+
+        attachments = sendgrid_handler._process_attachments([single_file_to_be_zipped, dir_to_be_zipped])
+
+        #: If we use TemporaryDirectory() as a context manager in _process_attachments, the zip files
+        #: no longer exist for these asserts to check.
+        assert len(attachments) == 2
+        assert zipfile.ZipFile(attachments[0]).namelist() == ['single.txt']
+        assert zipfile.ZipFile(attachments[1]).namelist() == ['zipme/', 'zipme/a.txt', 'zipme/b.txt']
+
+    def test_zip_whole_directory(self, mocker, tmp_path):
+        working_dir = tmp_path
+        dir_to_be_zipped = working_dir / 'zipme'
+        dir_to_be_zipped.mkdir()
+        temp_a = dir_to_be_zipped / 'a.txt'
+        temp_a.write_text('a')
+        temp_b = dir_to_be_zipped / 'b.txt'
+        temp_b.write_text('b')
+
+        sendgrid_mock = mocker.Mock()
+
+        zipped_path = message_handlers.SendGridHandler._zip_whole_directory(
+            sendgrid_mock, working_dir, dir_to_be_zipped
+        )
+
+        assert zipfile.ZipFile(zipped_path).namelist() == ['zipme/', 'zipme/a.txt', 'zipme/b.txt']
+
+    def test_zip_single_file(self, mocker, tmp_path):
+        working_dir = tmp_path
+        temp_a = working_dir / 'a.txt'
+        temp_a.write_text('a')
+        temp_dir = TemporaryDirectory().name
+
+        sendgrid_mock = mocker.Mock()
+
+        zipped_path = message_handlers.SendGridHandler._zip_single_file(sendgrid_mock, temp_dir, temp_a)
+
+        assert zipfile.ZipFile(zipped_path).namelist() == ['a.txt']
 
     def test_build_attachment_mock_file(self, mocker):
         mock_open = mock.mock_open(read_data=b'test data')
@@ -833,9 +912,10 @@ class TestSendGridHandlerAttachments:
         working_dir = tmp_path
         temp_a = working_dir / 'a.txt'
         temp_a.write_text('a')
+        temp_dir = TemporaryDirectory().name
 
         sendgrid_mock = mocker.Mock()
-        single_zip_path = message_handlers.SendGridHandler._zip_single_file(sendgrid_mock, working_dir, temp_a)
+        single_zip_path = message_handlers.SendGridHandler._zip_single_file(sendgrid_mock, temp_dir, temp_a)
 
         with open(single_zip_path, 'rb') as single_zip_file:
             data = single_zip_file.read()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 import sys
 import types
+from pathlib import Path
 
 from supervisor import message_handlers, models
 
@@ -53,3 +54,46 @@ def test_add_message_handler(mocker):
 
     assert len(sim_sup.message_handlers) == 1
     assert sim_sup.message_handlers[-1] == handler_mock
+
+
+class TestMesssageDetails:
+
+    def test_attachments_single_str(self, mocker):
+
+        message = models.MessageDetails()
+        message.attachments = r'c:\temp\foo.bar'
+
+        assert message.attachments == [r'c:\temp\foo.bar']
+
+    def test_attachments_single_Path(self, mocker):
+
+        message = models.MessageDetails()
+        message.attachments = Path(r'c:\temp\foo.bar')
+
+        assert message.attachments == [Path(r'c:\temp\foo.bar')]
+
+    def test_attachments_list_of_strs(self, mocker):
+
+        message = models.MessageDetails()
+        message.attachments = [r'c:\temp\foo.bar', r'c:\temp\bar.baz']
+
+        assert message.attachments == [r'c:\temp\foo.bar', r'c:\temp\bar.baz']
+
+    def test_attachments_list_of_Paths(self, mocker):
+
+        message = models.MessageDetails()
+        message.attachments = [Path(r'c:\temp\foo.bar'), Path(r'c:\temp\bar.baz')]
+
+        assert message.attachments == [Path(r'c:\temp\foo.bar'), Path(r'c:\temp\bar.baz')]
+
+    def test_attachments_mixed_list(self, mocker):
+        message = models.MessageDetails()
+        message.attachments = [r'c:\temp\foo.bar', Path(r'c:\temp\bar.baz')]
+
+        assert message.attachments == [r'c:\temp\foo.bar', Path(r'c:\temp\bar.baz')]
+
+    def test_attachment_empty_list(self, mocker):
+        message = models.MessageDetails()
+        message.attachments = []
+
+        assert message.attachments == []


### PR DESCRIPTION
This is a two-fer:

1. Implement a `SendGridHandler` for sending emails via SendGrid (with test cases). Use Zip instead of gzip for better Windows usability.
2. Consolidate `project_name` into the specific `MessageHandler`s rather than separate entries for both `Supervisor` and each `MessageDetail` object. Closes #8. 

The `project_name` consolidation changes the API for the existing `EmailHandler` object, so this will result in a major version bump to 2.0.