### PR TITLE
feat: Make supervisor more cloud-friendly

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,5 +34,4 @@
   "python.testing.nosetestsEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
-  "python.pythonPath": "C:\\Users\\jdadams\\Miniconda3\\envs\\supervisor\\python.exe"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,10 +29,10 @@
   ],
   "python.formatting.yapfPath": "yapf",
   "python.linting.enabled": true,
-  "python.linting.flake8Enabled": false,
   "python.linting.pycodestyleEnabled": false,
   "python.linting.pylintEnabled": true,
   "python.testing.nosetestsEnabled": false,
   "python.testing.pytestEnabled": true,
-  "python.testing.unittestEnabled": false
+  "python.testing.unittestEnabled": false,
+  "python.pythonPath": "C:\\Users\\jdadams\\Miniconda3\\envs\\supervisor\\python.exe"
 }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sendgrid_settings = {
    'to_address': 'you@utah.gov',
    'api_key': 'its_a_secret!',
 }
-supervisor.add_message_handler(SendGridHandler(sendgrid_settings=sendgrid_settings, project_name='my_project'))
+supervisor.add_message_handler(SendGridHandler(sendgrid_settings=sendgrid_settings, project_name='my_project', project_version='1.5.0'))
 supervisor.add_message_handler(ConsoleHandler())
 
 #: Do your stuff here...

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,7 @@
 
 `models.Supervisor`
 
-The Supervisor is the main object used to coordinate messaging and error handling. Implemented as a singleton.
+The Supervisor is the main object used to coordinate messaging and error handling. Informally implemented as a singleton.
 
 ### Attributes
 
@@ -21,7 +21,9 @@ The Supervisor is the main object used to coordinate messaging and error handlin
 
 #### Instantiation
 
-You'll instantiate a single Supervisor object to handle messaging and exceptions for the client program (whatever program you're wanting to automate through Windows Task Scheduler).
+You'll instantiate a single Supervisor object to handle messaging and (optionally) exceptions for the client program (whatever program you're wanting to automate through Windows Task Scheduler).
+
+By default, the Supervisor object will replace the built-in exception handler with one that sends a notification through the registered message handlers. If you don't want this behavior, pass `handle_error=False` when you instantiate the object.
 
 The optional logging arguments on the constructor can be used by the exception handler. The `logger` will be used to log any errors caught by the exception handler. `log_path` can be added as an attachment to any exception messages sent by the registered `MessageHandlers`.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -76,7 +76,7 @@ Relies on the `email_settings` parameter to set up the outgoing server settings.
 
 Optionally supports the `prefix` key in `email_settings`, which is a string that will be prepended to the message's subject line. You can use `socket.gethostname()` to include the current hostname.
 
-Optionally relies on the `project_name` parameter to report the client program's name and version number in the email.
+Optionally relies on the `client_name` and `client_version` parameters to report the client program's name and version number in the email.
 
 ### Supported MessageDetail Attributes
 
@@ -105,7 +105,7 @@ Relies on the `sendgrid_settings` parameter to set up the outgoing server settin
 
 Optionally supports the `prefix` key in `sendgrid_settings`, which is a string that will be prepended to the message's subject line. You can use `socket.gethostname()` to include the current hostname.
 
-Optionally relies on the `project_name` parameter to report the client program's name and version number in the email.
+Optionally relies on the `client_name` and `client_version` parameters to report the client program's name and version number in the email.
 
 ### Supported MessageDetail Attributes
 

--- a/src/supervisor/models.py
+++ b/src/supervisor/models.py
@@ -31,15 +31,16 @@ class Supervisor:
         Closure around a replacement for sys.excepthook
     """
 
-    def __init__(self, logger=None, log_path=None):
+    def __init__(self, handle_errors=True, logger=None, log_path=None):
 
         #: Set up our list of MessageHandlers
         self.message_handlers = []
         self.logger = logger
         self.log_path = log_path
 
-        #: Catch any uncaught exception with our custom exception handler
-        sys.excepthook = self._manage_exceptions()
+        #: Catch any uncaught exception with our custom exception handler if desired
+        if handle_errors:
+            sys.excepthook = self._manage_exceptions()
 
     def add_message_handler(self, handler: MessageHandler):
         """Register a new handler for sending messages

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -28,11 +28,6 @@ def test_console_handler_prints(mocker, capsys):
 
 def test_build_message_without_attachments(mocker):
 
-    distribution_Mock = mocker.Mock()
-    distribution_Mock.version = 0
-    distributions = [distribution_Mock]
-    mocker.patch('pkg_resources.require', return_value=distributions)
-
     message_details = MessageDetails()
     message_details.message = 'test_message'
     message_details.subject = 'test_subject'
@@ -42,7 +37,8 @@ def test_build_message_without_attachments(mocker):
         'to_addresses': 'foo@example.com',
         'from_address': 'testing@example.com',
     }
-    handler_mock.project_name = 'testing'
+    handler_mock.client_name = 'testing'
+    handler_mock.client_version = 0
 
     test_message = message_handlers.EmailHandler._build_message(handler_mock, message_details)
 
@@ -55,11 +51,6 @@ def test_build_message_without_attachments(mocker):
 
 def test_build_message_with_None_attachment(mocker):
 
-    distribution_Mock = mocker.Mock()
-    distribution_Mock.version = 0
-    distributions = [distribution_Mock]
-    mocker.patch('pkg_resources.require', return_value=distributions)
-
     message_details = MessageDetails()
     message_details.message = 'test_message'
     message_details.subject = 'test_subject'
@@ -70,7 +61,8 @@ def test_build_message_with_None_attachment(mocker):
         'to_addresses': 'foo@example.com',
         'from_address': 'testing@example.com',
     }
-    handler_mock.project_name = 'testing'
+    handler_mock.client_name = 'testing'
+    handler_mock.client_version = 0
 
     test_message = message_handlers.EmailHandler._build_message(handler_mock, message_details)
 
@@ -83,11 +75,6 @@ def test_build_message_with_None_attachment(mocker):
 
 def test_build_message_with_empty_str_attachment_path(mocker):
 
-    distribution_Mock = mocker.Mock()
-    distribution_Mock.version = 0
-    distributions = [distribution_Mock]
-    mocker.patch('pkg_resources.require', return_value=distributions)
-
     message_details = MessageDetails()
     message_details.message = 'test_message'
     message_details.subject = 'test_subject'
@@ -98,7 +85,8 @@ def test_build_message_with_empty_str_attachment_path(mocker):
         'to_addresses': 'foo@example.com',
         'from_address': 'testing@example.com',
     }
-    handler_mock.project_name = 'testing'
+    handler_mock.client_name = 'testing'
+    handler_mock.client_version = 0
 
     test_message = message_handlers.EmailHandler._build_message(handler_mock, message_details)
 
@@ -111,11 +99,6 @@ def test_build_message_with_empty_str_attachment_path(mocker):
 
 def test_build_message_with_subject_prefix(mocker):
 
-    distribution_Mock = mocker.Mock()
-    distribution_Mock.version = 0
-    distributions = [distribution_Mock]
-    mocker.patch('pkg_resources.require', return_value=distributions)
-
     message_details = MessageDetails()
     message_details.message = 'test_message'
     message_details.subject = 'test_subject'
@@ -126,7 +109,8 @@ def test_build_message_with_subject_prefix(mocker):
         'from_address': 'testing@example.com',
         'prefix': 'test prefix: ',
     }
-    handler_mock.project_name = 'testing'
+    handler_mock.client_name = 'testing'
+    handler_mock.client_version = 0
 
     test_message = message_handlers.EmailHandler._build_message(handler_mock, message_details)
 
@@ -138,12 +122,6 @@ def test_build_message_with_subject_prefix(mocker):
 
 
 def test_build_message_with_multiple_to_addresses(mocker):
-
-    distribution_Mock = mocker.Mock()
-    distribution_Mock.version = 0
-    distributions = [distribution_Mock]
-    mocker.patch('pkg_resources.require', return_value=distributions)
-
     message_details = MessageDetails()
     message_details.message = 'test_message'
     message_details.subject = 'test_subject'
@@ -153,7 +131,8 @@ def test_build_message_with_multiple_to_addresses(mocker):
         'to_addresses': ['foo@example.com', 'bar@example.com', 'baz@example.com'],
         'from_address': 'testing@example.com',
     }
-    handler_mock.project_name = 'testing'
+    handler_mock.client_name = 'testing'
+    handler_mock.client_version = 0
 
     test_message = message_handlers.EmailHandler._build_message(handler_mock, message_details)
 
@@ -483,32 +462,16 @@ class TestSendGridHandlerParts:
         assert subject == 'Bar Prefix—Foo Subject'
 
     def test_build_content_with_version(self, mocker):
-        distribution_Mock = mocker.Mock()
-        distribution_Mock.version = 0
-        distributions = [distribution_Mock]
-        mocker.patch('pkg_resources.require', return_value=distributions)
 
         message_details = models.MessageDetails()
         message_details.message = 'This is a\nmessage with newlines'
-        message_details.project_name = 'ProFoo'
+        client_name = 'ProFoo'
+        client_version = 0
 
         content_object = message_handlers.SendGridHandler._build_content(
-            message_details.message, message_details.project_name
+            message_details.message, client_name, client_version
         )
         assert content_object.content == 'This is a\nmessage with newlines\n\nProFoo version: 0'
-        assert content_object.mime_type == 'text/plain'
-
-    def test_build_content_without_version(self, mocker):
-        mocker.patch('pkg_resources.require', return_value=[])
-
-        message_details = models.MessageDetails()
-        message_details.message = 'This is a\nmessage with newlines'
-        message_details.project_name = 'ProFoo'
-
-        content_object = message_handlers.SendGridHandler._build_content(
-            message_details.message, message_details.project_name
-        )
-        assert content_object.content == 'This is a\nmessage with newlines'
         assert content_object.mime_type == 'text/plain'
 
     def test_verify_attachments_bad_Path_input(self, mocker):
@@ -712,11 +675,6 @@ class TestSendGridHandlerWhole:
 
         sg_api_mock = mocker.patch('sendgrid.SendGridAPIClient')
 
-        distribution_Mock = mocker.Mock()
-        distribution_Mock.version = 3.14
-        distributions = [distribution_Mock]
-        mocker.patch('pkg_resources.require', return_value=distributions)
-
         sendgrid_settings = {
             'from_address': 'foo@example.com',
             'to_addresses': 'cheddar@example.com',
@@ -726,7 +684,7 @@ class TestSendGridHandlerWhole:
         message_details = models.MessageDetails()
         message_details.message = 'This is a\nmulti-line\nmessage'
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo', '3.14')
 
         sendgrid_handler.send_message(message_details)
 
@@ -740,11 +698,6 @@ class TestSendGridHandlerWhole:
     def test_send_message_full_integration_with_single_file_attachment(self, mocker, tmp_path):
 
         sg_api_mock = mocker.patch('sendgrid.SendGridAPIClient')
-
-        distribution_Mock = mocker.Mock()
-        distribution_Mock.version = 3.14
-        distributions = [distribution_Mock]
-        mocker.patch('pkg_resources.require', return_value=distributions)
 
         sendgrid_settings = {
             'from_address': 'foo@example.com',
@@ -760,7 +713,7 @@ class TestSendGridHandlerWhole:
         message_details.message = 'This is a\nmulti-line\nmessage'
         message_details.attachments = [temp_a]
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo', '3.14')
 
         sendgrid_handler.send_message(message_details)
 
@@ -774,11 +727,6 @@ class TestSendGridHandlerWhole:
     def test_send_message_full_integration_with_directory_attachment(self, mocker, tmp_path):
 
         sg_api_mock = mocker.patch('sendgrid.SendGridAPIClient')
-
-        distribution_Mock = mocker.Mock()
-        distribution_Mock.version = 3.14
-        distributions = [distribution_Mock]
-        mocker.patch('pkg_resources.require', return_value=distributions)
 
         sendgrid_settings = {
             'from_address': 'foo@example.com',
@@ -798,7 +746,7 @@ class TestSendGridHandlerWhole:
         message_details.message = 'This is a\nmulti-line\nmessage'
         message_details.attachments = [dir_to_be_attached]
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo', '3.14')
 
         sendgrid_handler.send_message(message_details)
 
@@ -812,11 +760,6 @@ class TestSendGridHandlerWhole:
     def test_send_message_full_integration_with_directory_and_single_file_attachments(self, mocker, tmp_path):
 
         sg_api_mock = mocker.patch('sendgrid.SendGridAPIClient')
-
-        distribution_Mock = mocker.Mock()
-        distribution_Mock.version = 3.14
-        distributions = [distribution_Mock]
-        mocker.patch('pkg_resources.require', return_value=distributions)
 
         sendgrid_settings = {
             'from_address': 'foo@example.com',
@@ -840,7 +783,7 @@ class TestSendGridHandlerWhole:
         message_details.message = 'This is a\nmulti-line\nmessage'
         message_details.attachments = [dir_to_be_attached, single_file]
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo', '3.14')
 
         sendgrid_handler.send_message(message_details)
 
@@ -856,11 +799,6 @@ class TestSendGridHandlerWhole:
     def test_send_message_full_integration_with_single_file_and_directory_attachments(self, mocker, tmp_path):
 
         sg_api_mock = mocker.patch('sendgrid.SendGridAPIClient')
-
-        distribution_Mock = mocker.Mock()
-        distribution_Mock.version = 3.14
-        distributions = [distribution_Mock]
-        mocker.patch('pkg_resources.require', return_value=distributions)
 
         sendgrid_settings = {
             'from_address': 'foo@example.com',
@@ -884,7 +822,7 @@ class TestSendGridHandlerWhole:
         message_details.message = 'This is a\nmulti-line\nmessage'
         message_details.attachments = [single_file, dir_to_be_attached]
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo', '3.14')
 
         sendgrid_handler.send_message(message_details)
 
@@ -901,11 +839,6 @@ class TestSendGridHandlerWhole:
 
         sg_api_mock = mocker.patch('sendgrid.SendGridAPIClient')
 
-        distribution_Mock = mocker.Mock()
-        distribution_Mock.version = 3.14
-        distributions = [distribution_Mock]
-        mocker.patch('pkg_resources.require', return_value=distributions)
-
         sendgrid_settings = {
             'from_address': 'foo@example.com',
             'to_addresses': 'cheddar@example.com',
@@ -918,7 +851,7 @@ class TestSendGridHandlerWhole:
         message_details.message = 'This is a\nmulti-line\nmessage'
         message_details.attachments = [bad_file]
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo', '3.14')
 
         sendgrid_handler.send_message(message_details)
 
@@ -934,11 +867,6 @@ class TestSendGridHandlerWhole:
 
         sg_api_mock = mocker.patch('sendgrid.SendGridAPIClient')
 
-        distribution_Mock = mocker.Mock()
-        distribution_Mock.version = 3.14
-        distributions = [distribution_Mock]
-        mocker.patch('pkg_resources.require', return_value=distributions)
-
         sendgrid_settings = {
             'from_address': 'foo@example.com',
             'to_addresses': 'cheddar@example.com',
@@ -949,7 +877,7 @@ class TestSendGridHandlerWhole:
         message_details.message = 'This is a\nmulti-line\nmessage'
         message_details.attachments = [3]
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo', '3.14')
 
         sendgrid_handler.send_message(message_details)
 
@@ -965,11 +893,6 @@ class TestSendGridHandlerWhole:
 
         sg_api_mock = mocker.patch('sendgrid.SendGridAPIClient')
 
-        distribution_Mock = mocker.Mock()
-        distribution_Mock.version = 3.14
-        distributions = [distribution_Mock]
-        mocker.patch('pkg_resources.require', return_value=distributions)
-
         sendgrid_settings = {
             'from_address': 'foo@example.com',
             'to_addresses': 'cheddar@example.com',
@@ -983,7 +906,7 @@ class TestSendGridHandlerWhole:
         message_details.message = 'This is a\nmulti-line\nmessage'
         message_details.attachments = [good_file, 3]
 
-        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo')
+        sendgrid_handler = message_handlers.SendGridHandler(sendgrid_settings, 'ProFoo', '3.14')
 
         sendgrid_handler.send_message(message_details)
 


### PR DESCRIPTION
Two fixes to make supervisor work in google cloud functions (and other non-pip-installed environments):

1.  Make the error handler optional (defaults to True)
2. Pass the client version to the MessageHandlers rather than try to derive it. This puts the responsibility for determining the version on the client instead of on supervisor, eliminating the pkg_resources dependency and enabling use if your client isn't pip installed. 