### PR TITLE
fix: separate build from deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,9 @@ env:
   GH_TOKEN: ${{ github.token }}
 
 jobs:
-  publish:
-    name: Build and Publish
+  build:
+    name: Build
     runs-on: ubuntu-latest
-    environment:
-      name: prod
-      url: https://pypi.org/project/ugrc-supervisor
-    permissions:
-      id-token: write
-
     steps:
       - name: ⬇️ Set up code
         uses: actions/checkout@v4
@@ -31,6 +25,30 @@ jobs:
 
       - name: 📦 Build package
         run: pipx run build
+
+      - name: ⬆️ Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: dist
+          retention-days: 1
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: prod
+      url: https://pypi.org/project/ugrc-supervisor
+    permissions:
+      id-token: write
+
+    steps:
+      - name: ⬇️ Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+          path: dist
 
       - name: 🚀 Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
For security reasons: https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/#:~:text=try%20to%20separate%20building%20from%20publishing