### PR TITLE
feat: remove requests pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
     },
     keywords=["gis"],
     install_requires=[
-        "requests==2.31",
         "sendgrid==6.*",
     ],
     extras_require={


### PR DESCRIPTION
As of arcgis 2.4.0, the requests pin doesn't seem to be needed anymore.